### PR TITLE
CCP-65: Serializers for Discussions

### DIFF
--- a/app/discussions/models.py
+++ b/app/discussions/models.py
@@ -8,10 +8,11 @@ from app.users.models import User
 
 class Message(TimeStampedModel):
     text = models.TextField()
-    session = models.ForeignKey(to=Session, on_delete=models.CASCADE)
-    author = models.ForeignKey(to=User, on_delete=models.CASCADE)
+    session = models.ForeignKey(to=Session, on_delete=models.CASCADE, related_name='messages')
+    author = models.ForeignKey(to=User, on_delete=models.CASCADE, related_name='messages')
     time = models.DateTimeField()
-    origin_slack_event = models.ForeignKey(to=SlackEvent, on_delete=models.CASCADE, related_name='message', null=True)
+    origin_slack_event = models.ForeignKey(to=SlackEvent, on_delete=models.CASCADE, related_name='message', blank=True,
+                                           null=True)
 
     def __str__(self):
         return f'Message on {self.time}'
@@ -19,8 +20,8 @@ class Message(TimeStampedModel):
 
 class Reply(TimeStampedModel):
     text = models.TextField()
-    message = models.ForeignKey(to=Message, on_delete=models.CASCADE)
-    author = models.ForeignKey(to=User, on_delete=models.CASCADE)
+    message = models.ForeignKey(to=Message, on_delete=models.CASCADE, related_name='replies')
+    author = models.ForeignKey(to=User, on_delete=models.CASCADE, related_name='replies')
     time = models.DateTimeField()
     origin_slack_event = models.OneToOneField(to=SlackEvent, on_delete=models.CASCADE, related_name='reply', blank=True,
                                               null=True)

--- a/app/discussions/models.py
+++ b/app/discussions/models.py
@@ -22,7 +22,8 @@ class Reply(TimeStampedModel):
     message = models.ForeignKey(to=Message, on_delete=models.CASCADE)
     author = models.ForeignKey(to=User, on_delete=models.CASCADE)
     time = models.DateTimeField()
-    origin_slack_event = models.ForeignKey(to=SlackEvent, on_delete=models.CASCADE, related_name='reply', null=True)
+    origin_slack_event = models.OneToOneField(to=SlackEvent, on_delete=models.CASCADE, related_name='reply', blank=True,
+                                              null=True)
 
     class Meta:
         verbose_name_plural = 'Replies'

--- a/app/discussions/mutations.py
+++ b/app/discussions/mutations.py
@@ -1,6 +1,7 @@
 import graphene
 
 from app.discussions.models import Message, Reply
+from app.discussions.serializers import MessageSerializer, ReplySerializer
 from app.discussions.types import (
     MessageType,
     ReplyType,
@@ -19,7 +20,9 @@ class CreateMessageMutation(graphene.Mutation):
         if not info.context.user.is_authenticated:
             raise Exception('Unauthorized')
 
-        message = Message.objects.create(**input)
+        message_serializer = MessageSerializer(data=input)
+        message_serializer.is_valid(raise_exception=True)
+        message = message_serializer.save()
         return CreateMessageMutation(message=message)
 
 
@@ -33,7 +36,9 @@ class CreateReplyMutation(graphene.Mutation):
         if not info.context.user.is_authenticated:
             raise Exception('Unauthorized')
 
-        reply = Reply.objects.create(**input)
+        reply_serializer = ReplySerializer(data=input)
+        reply_serializer.is_valid(raise_exception=True)
+        reply = reply_serializer.save()
         return CreateReplyMutation(reply=reply)
 
 

--- a/app/discussions/mutations.py
+++ b/app/discussions/mutations.py
@@ -1,6 +1,5 @@
 import graphene
 
-from app.discussions.models import Message, Reply
 from app.discussions.serializers import MessageSerializer, ReplySerializer
 from app.discussions.types import (
     MessageType,

--- a/app/discussions/mutations.py
+++ b/app/discussions/mutations.py
@@ -19,9 +19,9 @@ class CreateMessageMutation(graphene.Mutation):
         if not info.context.user.is_authenticated:
             raise Exception('Unauthorized')
 
-        message_serializer = MessageValidator(data=input)
-        message_serializer.is_valid(raise_exception=True)
-        message = message_serializer.save()
+        message_validator = MessageValidator(data=input)
+        message_validator.is_valid(raise_exception=True)
+        message = message_validator.save()
         return CreateMessageMutation(message=message)
 
 
@@ -35,9 +35,9 @@ class CreateReplyMutation(graphene.Mutation):
         if not info.context.user.is_authenticated:
             raise Exception('Unauthorized')
 
-        reply_serializer = ReplyValidator(data=input)
-        reply_serializer.is_valid(raise_exception=True)
-        reply = reply_serializer.save()
+        reply_validator = ReplyValidator(data=input)
+        reply_validator.is_valid(raise_exception=True)
+        reply = reply_validator.save()
         return CreateReplyMutation(reply=reply)
 
 

--- a/app/discussions/mutations.py
+++ b/app/discussions/mutations.py
@@ -1,6 +1,6 @@
 import graphene
 
-from app.discussions.serializers import MessageSerializer, ReplySerializer
+from app.discussions.validators import MessageValidator, ReplyValidator
 from app.discussions.types import (
     MessageType,
     ReplyType,
@@ -19,7 +19,7 @@ class CreateMessageMutation(graphene.Mutation):
         if not info.context.user.is_authenticated:
             raise Exception('Unauthorized')
 
-        message_serializer = MessageSerializer(data=input)
+        message_serializer = MessageValidator(data=input)
         message_serializer.is_valid(raise_exception=True)
         message = message_serializer.save()
         return CreateMessageMutation(message=message)
@@ -35,7 +35,7 @@ class CreateReplyMutation(graphene.Mutation):
         if not info.context.user.is_authenticated:
             raise Exception('Unauthorized')
 
-        reply_serializer = ReplySerializer(data=input)
+        reply_serializer = ReplyValidator(data=input)
         reply_serializer.is_valid(raise_exception=True)
         reply = reply_serializer.save()
         return CreateReplyMutation(reply=reply)

--- a/app/discussions/serializers.py
+++ b/app/discussions/serializers.py
@@ -1,0 +1,23 @@
+from rest_framework import serializers
+
+from app.discussions.models import Message, Reply
+from app.questions.models import Session
+from app.users.models import User
+
+
+class MessageSerializer(serializers.ModelSerializer):
+    session_id = serializers.PrimaryKeyRelatedField(queryset=Session.objects.all(), source='session')
+    author_id = serializers.PrimaryKeyRelatedField(queryset=User.objects.all(), source='author')
+
+    class Meta:
+        model = Message
+        fields = ('id', 'text', 'session_id', 'author_id', 'time')
+
+
+class ReplySerializer(serializers.ModelSerializer):
+    message_id = serializers.PrimaryKeyRelatedField(queryset=Message.objects.all(), source='message')
+    author_id = serializers.PrimaryKeyRelatedField(queryset=User.objects.all(), source='author')
+
+    class Meta:
+        model = Reply
+        fields = ('id', 'text', 'message_id', 'author_id', 'time')

--- a/app/discussions/validators.py
+++ b/app/discussions/validators.py
@@ -1,3 +1,5 @@
+# Use of serializers limited to validating and saving models.
+
 from rest_framework import serializers
 
 from app.discussions.models import Message, Reply
@@ -5,7 +7,7 @@ from app.questions.models import Session
 from app.users.models import User
 
 
-class MessageSerializer(serializers.ModelSerializer):
+class MessageValidator(serializers.ModelSerializer):
     session_id = serializers.PrimaryKeyRelatedField(queryset=Session.objects.all(), source='session')
     author_id = serializers.PrimaryKeyRelatedField(queryset=User.objects.all(), source='author')
 
@@ -14,7 +16,7 @@ class MessageSerializer(serializers.ModelSerializer):
         fields = ('id', 'text', 'session_id', 'author_id', 'time')
 
 
-class ReplySerializer(serializers.ModelSerializer):
+class ReplyValidator(serializers.ModelSerializer):
     message_id = serializers.PrimaryKeyRelatedField(queryset=Message.objects.all(), source='message')
     author_id = serializers.PrimaryKeyRelatedField(queryset=User.objects.all(), source='author')
 


### PR DESCRIPTION
Nuance here is with the `PrimaryKeyRelatedField`. REST serializers have a number of options for serializing relationships. For GraphQL, we don't care much about the output serialization, as GraphQL handles that with the DjangoObjectType. However, we do care about the input validation. We want to pass in minimal data (e.g. just ID). In Django REST, the field name would not change (e.g. author will map to id). In GraphQL, it makes more sense to specify the field as author_id because author would better refer to an input type for a new author. Because of this, we override the naming on the serializer fields and override the source of the PrimaryKeyRelatedFields.