### PR TITLE
CCP-31: Resolve nullable ForeignKey for relevant Graphene types

### DIFF
--- a/app/questions/models.py
+++ b/app/questions/models.py
@@ -21,9 +21,9 @@ class Question(TimeStampedModel):
 
     original_poster = models.ForeignKey(to=User, on_delete=models.DO_NOTHING, related_name='asked_questions')
     solver = models.ForeignKey(to=User, on_delete=models.DO_NOTHING, null=True, related_name='solved_questions')
-    group = models.ForeignKey(to=Group, on_delete=models.CASCADE)
+    group = models.ForeignKey(to=Group, on_delete=models.CASCADE, related_name='questions')
 
-    tags = models.ManyToManyField(to=Tag)
+    tags = models.ManyToManyField(to=Tag, related_name='questions')
 
     def solve(self, time_end):
         self.is_solved = True


### PR DESCRIPTION
- This issue was resolved through previous commits/migrations and adding JSON fixtures
- It looks like if no data is in the database, it doesn't drill down into related types and return a list of empty dicts but instead only returns a top-level empty array, which makes sense.