### PR TITLE
CCP-53: Update message and reply time field to convert SlackEvent timestamp to date

### DIFF
--- a/app/slack_integration/mutations.py
+++ b/app/slack_integration/mutations.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from django.conf import settings
 import graphene
 import requests
@@ -188,7 +190,8 @@ class CreateMessageFromSlackMutation(graphene.Mutation):
         session = Session.objects.get(slackchannel__id=input['slack_channel_id'])
         author = User.objects.get(slack_users__id=input['slack_user_id'])
 
-        message_validator = MessageValidator(data=dict(text=input['text'], time=input['time'], session_id=session.id,
+        time = datetime.fromtimestamp(int(slack_event.ts.split('.')[0]))
+        message_validator = MessageValidator(data=dict(text=input['text'], time=time, session_id=session.id,
                                                        author_id=author.id, origin_slack_event_id=slack_event.id))
         message_validator.is_valid(raise_exception=True)
         message = message_validator.save()
@@ -224,7 +227,8 @@ class CreateUserAndMessageFromSlackMutation(graphene.Mutation):
         slack_event = SlackEvent.objects.create(ts=input.pop('origin_slack_event_ts'))
         session = Session.objects.get(slackchannel__id=input['slack_channel_id'])
 
-        message_validator = MessageValidator(data=dict(text=input['text'], time=input['time'], session_id=session.id,
+        time = datetime.fromtimestamp(int(slack_event.ts.split('.')[0]))
+        message_validator = MessageValidator(data=dict(text=input['text'], time=time, session_id=session.id,
                                                        author_id=user.id, origin_slack_event_id=slack_event.id))
         message_validator.is_valid(raise_exception=True)
         message = message_validator.save()
@@ -250,8 +254,9 @@ class CreateReplyFromSlackMutation(graphene.Mutation):
                                       session__slackchannel__id=input['slack_channel_id'])
         author = User.objects.get(slack_users__id=input['slack_user_id'])
 
+        time = datetime.fromtimestamp(int(slack_event.ts.split('.')[0]))
         reply_validator = ReplyValidator(data=dict(text=input['text'], message_id=message.id, author_id=author.id,
-                                                   origin_slack_event_id=slack_event.id, time=input['time']))
+                                                   origin_slack_event_id=slack_event.id, time=time))
         reply_validator.is_valid(raise_exception=True)
         reply = reply_validator.save()
 
@@ -287,7 +292,8 @@ class CreateUserAndReplyFromSlackMutation(graphene.Mutation):
         message = Message.objects.get(origin_slack_event__ts=input['message_origin_slack_event_ts'],
                                       session__slackchannel__id=input['slack_channel_id'])
 
-        reply_validator = ReplyValidator(data=dict(text=input['text'], time=input['time'], author_id=user.id,
+        time = datetime.fromtimestamp(int(slack_event.ts.split('.')[0]))
+        reply_validator = ReplyValidator(data=dict(text=input['text'], time=time, author_id=user.id,
                                                    message_id=message.id, origin_slack_event_id=slack_event.id))
         reply_validator.is_valid(raise_exception=True)
         reply = reply_validator.save()

--- a/app/slack_integration/types.py
+++ b/app/slack_integration/types.py
@@ -81,7 +81,6 @@ class MessageFromSlackInputType(graphene.InputObjectType):
     slack_channel_id = graphene.String(required=True)
     slack_user_id = graphene.String(required=True)
     text = graphene.String(required=True)
-    time = graphene.String(required=True)
 
 
 class ReplyFromSlackInputType(graphene.InputObjectType):
@@ -90,7 +89,6 @@ class ReplyFromSlackInputType(graphene.InputObjectType):
     slack_channel_id = graphene.String(required=True)
     slack_user_id = graphene.String(required=True)
     text = graphene.String(required=True)
-    time = graphene.String(required=True)
 
 
 class SessionFromSlackInputType(graphene.InputObjectType):
@@ -119,7 +117,6 @@ class UserAndMessageFromSlackInputType(graphene.InputObjectType):
     origin_slack_event_ts = graphene.String(required=True)
     slack_channel_id = graphene.String(required=True)
     text = graphene.String(required=True)
-    time = graphene.String(required=True)
 
 
 class UserAndReplyFromSlackInputType(graphene.InputObjectType):
@@ -128,7 +125,6 @@ class UserAndReplyFromSlackInputType(graphene.InputObjectType):
     origin_slack_event_ts = graphene.String(required=True)
     slack_channel_id = graphene.String(required=True)
     text = graphene.String(required=True)
-    time = graphene.String(required=True)
 
 
 class GroupFromSlackInputType(graphene.InputObjectType):

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -110,7 +110,7 @@ class SlackEventFactory(factory.DjangoModelFactory):
     class Meta:
         model = SlackEvent
 
-    ts = factory.LazyAttribute(lambda x: f'''{factory.Faker('unix_time')}''')
+    ts = factory.Faker('unix_time')
 
 
 class SlackTeamFactory(factory.DjangoModelFactory):

--- a/tests/func/slack_integration/test_create_message_from_slack.py
+++ b/tests/func/slack_integration/test_create_message_from_slack.py
@@ -15,7 +15,7 @@ class TestCreateMessageFromSlack:
 
         mutation = f'''
           mutation {{
-            createMessageFromSlack(input: {{text: "{message.text}", time: "{message.time}",
+            createMessageFromSlack(input: {{text: "{message.text}",
                                             slackChannelId: "{slack_channel.id}", slackUserId: "{slack_user.id}",
                                             originSlackEventTs: "{slack_event.ts}"}}) {{
               message {{
@@ -46,7 +46,7 @@ class TestCreateMessageFromSlack:
 
         mutation = f'''
           mutation {{
-            createMessageFromSlack(input: {{text: "{message.text}", time: "{message.time}",
+            createMessageFromSlack(input: {{text: "{message.text}",
                                             slackChannelId: "{slack_channel.id}", slackUserId: "{slack_user.id}",
                                             originSlackEventTs: "{slack_event.ts}"}}) {{
               message {{
@@ -77,7 +77,7 @@ class TestCreateMessageFromSlack:
 
         mutation = f'''
           mutation {{
-            createMessageFromSlack(input: {{text: "{message.text}", time: "{message.time}",
+            createMessageFromSlack(input: {{text: "{message.text}",
                                             slackChannelId: "{slack_channel.id}", slackUserId: "{slack_user.id}",
                                             originSlackEventTs: "{slack_event.ts}"}}) {{
               message {{
@@ -108,7 +108,7 @@ class TestCreateMessageFromSlack:
 
         mutation = f'''
           mutation {{
-            createMessageFromSlack(input: {{text: "{message.text}", time: "{message.time}",
+            createMessageFromSlack(input: {{text: "{message.text}",
                                             slackChannelId: "{slack_channel.id}", slackUserId: "{slack_user.id}",
                                             originSlackEventTs: "{slack_event.ts}"}}) {{
               message {{
@@ -134,6 +134,7 @@ class TestCreateMessageFromSlack:
         assert response.json()['data']['createMessageFromSlack']['message']['author']['id'] == \
             str(slack_user.user.id)
         assert response.json()['data']['createMessageFromSlack']['message']['session']['id'] == str(session.id)
-        assert response.json()['data']['createMessageFromSlack']['message']['originSlackEvent']['ts'] == slack_event.ts
+        assert response.json()['data']['createMessageFromSlack']['message']['originSlackEvent']['ts'] == \
+            str(slack_event.ts)
         assert {'id': str(user.id)} in response.json()['data']['createMessageFromSlack']['message']['session'][
             'participants']

--- a/tests/func/slack_integration/test_create_reply_from_slack.py
+++ b/tests/func/slack_integration/test_create_reply_from_slack.py
@@ -19,7 +19,7 @@ class TestCreateReplyFromSlack:
 
         mutation = f'''
           mutation {{
-            createReplyFromSlack(input: {{text: "{reply.text}", time: "{reply.time}",
+            createReplyFromSlack(input: {{text: "{reply.text}",
                                           messageOriginSlackEventTs: "{message_slack_event.ts}",
                                           slackChannelId: "{slack_channel.id}",
                                           slackUserId: "{reply_slack_user.id}",
@@ -56,7 +56,7 @@ class TestCreateReplyFromSlack:
 
         mutation = f'''
           mutation {{
-            createReplyFromSlack(input: {{text: "{reply.text}", time: "{reply.time}",
+            createReplyFromSlack(input: {{text: "{reply.text}",
                                           messageOriginSlackEventTs: "{message_slack_event.ts}",
                                           slackChannelId: "{slack_channel.id}",
                                           slackUserId: "{reply_slack_user.id}",
@@ -93,7 +93,7 @@ class TestCreateReplyFromSlack:
 
         mutation = f'''
           mutation {{
-            createReplyFromSlack(input: {{text: "{reply.text}", time: "{reply.time}",
+            createReplyFromSlack(input: {{text: "{reply.text}",
                                           messageOriginSlackEventTs: "{message_slack_event.ts}",
                                           slackChannelId: "{slack_channel.id}",
                                           slackUserId: "{reply_slack_user.id}",
@@ -132,7 +132,7 @@ class TestCreateReplyFromSlack:
 
         mutation = f'''
           mutation {{
-            createReplyFromSlack(input: {{text: "{reply.text}", time: "{reply.time}",
+            createReplyFromSlack(input: {{text: "{reply.text}",
                                           messageOriginSlackEventTs: "{wrong_message_slack_event.ts}",
                                           slackChannelId: "{slack_channel.id}",
                                           slackUserId: "{reply_slack_user.id}",
@@ -170,7 +170,7 @@ class TestCreateReplyFromSlack:
 
         mutation = f'''
           mutation {{
-            createReplyFromSlack(input: {{text: "{reply.text}", time: "{reply.time}",
+            createReplyFromSlack(input: {{text: "{reply.text}",
                                           messageOriginSlackEventTs: "{message_slack_event.ts}",
                                           slackChannelId: "{slack_channel.id}",
                                           slackUserId: "{reply_slack_user.id}",
@@ -197,7 +197,7 @@ class TestCreateReplyFromSlack:
 
         assert response.status_code == 200
         assert response.json()['data']['createReplyFromSlack']['reply']['originSlackEvent']['ts'] == \
-            reply_slack_event.ts
+            str(reply_slack_event.ts)
         assert response.json()['data']['createReplyFromSlack']['reply']['message']['author']['id'] == \
             str(message.author.id)
         assert {'id': str(reply_slack_user.user.id)} in response.json()['data']['createReplyFromSlack']['reply'][

--- a/tests/func/slack_integration/test_create_user_and_message_from_slack.py
+++ b/tests/func/slack_integration/test_create_user_and_message_from_slack.py
@@ -27,8 +27,7 @@ class TestCreateUserAndMessageFromSlack:
                                                                 slackTeamId: "{slack_user.slack_team_id}"}},
                                                     originSlackEventTs: "{slack_event.ts}",
                                                     slackChannelId: "{slack_channel.id}",
-                                                    text: "{message.text}",
-                                                    time: "{message.time}"}}) {{
+                                                    text: "{message.text}"}}) {{
               slackUser {{
                 user {{
                   firstName
@@ -38,7 +37,7 @@ class TestCreateUserAndMessageFromSlack:
           }}
         '''
         response = client.post('/graphql', {'query': mutation})
-
+        print(response.content)
         assert response.status_code == 200
         assert response.json()['data']['createUserAndMessageFromSlack'] is None
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
@@ -67,8 +66,7 @@ class TestCreateUserAndMessageFromSlack:
                                                                 slackTeamId: "{slack_user.slack_team_id}"}},
                                                     originSlackEventTs: "{slack_event.ts}",
                                                     slackChannelId: "{slack_channel.id}",
-                                                    text: "{message.text}",
-                                                    time: "{message.time}"}}) {{
+                                                    text: "{message.text}"}}) {{
               slackUser {{
                 user {{
                   firstName
@@ -106,8 +104,7 @@ class TestCreateUserAndMessageFromSlack:
                                                                 slackTeamId: "{slack_user.slack_team_id}"}},
                                                     originSlackEventTs: "{slack_event.ts}",
                                                     slackChannelId: "{slack_channel.id}",
-                                                    text: "{message.text}",
-                                                    time: "{message.time}"}}) {{
+                                                    text: "{message.text}"}}) {{
               slackUser {{
                 user {{
                   firstName
@@ -148,8 +145,7 @@ class TestCreateUserAndMessageFromSlack:
                                                                 slackTeamId: "{slack_user.slack_team_id}"}},
                                                     originSlackEventTs: "{slack_event.ts}",
                                                     slackChannelId: "{slack_channel.id}",
-                                                    text: "{message.text}",
-                                                    time: "{message.time}"}}) {{
+                                                    text: "{message.text}"}}) {{
               slackUser {{
                 user {{
                   firstName
@@ -188,8 +184,7 @@ class TestCreateUserAndMessageFromSlack:
                                                                 slackTeamId: "{slack_user.slack_team_id}"}},
                                                     originSlackEventTs: "{slack_event.ts}",
                                                     slackChannelId: "{slack_channel.id}",
-                                                    text: "{message.text}",
-                                                    time: "{message.time}"}}) {{
+                                                    text: "{message.text}"}}) {{
               slackUser {{
                 user {{
                   firstName

--- a/tests/func/slack_integration/test_create_user_and_message_from_slack.py
+++ b/tests/func/slack_integration/test_create_user_and_message_from_slack.py
@@ -37,7 +37,7 @@ class TestCreateUserAndMessageFromSlack:
           }}
         '''
         response = client.post('/graphql', {'query': mutation})
-        print(response.content)
+
         assert response.status_code == 200
         assert response.json()['data']['createUserAndMessageFromSlack'] is None
         assert response.json()['errors'][0]['message'] == 'Unauthorized'

--- a/tests/func/slack_integration/test_create_user_and_reply_from_slack.py
+++ b/tests/func/slack_integration/test_create_user_and_reply_from_slack.py
@@ -33,8 +33,7 @@ class TestCreateUserAndReplyFromSlack:
                                                  messageOriginSlackEventTs: "{reply.message.origin_slack_event.ts}",
                                                  originSlackEventTs: "{reply.origin_slack_event.ts}",
                                                  slackChannelId: "{slack_channel.id}",
-                                                 text: "{reply.text}",
-                                                 time: "{reply.time}"}}) {{
+                                                 text: "{reply.text}"}}) {{
               slackUser {{
                 name
               }}
@@ -85,8 +84,7 @@ class TestCreateUserAndReplyFromSlack:
                                                  messageOriginSlackEventTs: "{reply.message.origin_slack_event.ts}",
                                                  originSlackEventTs: "{reply.origin_slack_event.ts}",
                                                  slackChannelId: "{slack_channel.id}",
-                                                 text: "{reply.text}",
-                                                 time: "{reply.time}"}}) {{
+                                                 text: "{reply.text}"}}) {{
               slackUser {{
                 name
               }}
@@ -137,8 +135,7 @@ class TestCreateUserAndReplyFromSlack:
                                                  messageOriginSlackEventTs: "{reply.message.origin_slack_event.ts}",
                                                  originSlackEventTs: "{reply.origin_slack_event.ts}",
                                                  slackChannelId: "{slack_channel.id}",
-                                                 text: "{reply.text}",
-                                                 time: "{reply.time}"}}) {{
+                                                 text: "{reply.text}"}}) {{
               slackUser {{
                 name
               }}
@@ -190,8 +187,7 @@ class TestCreateUserAndReplyFromSlack:
                                                  messageOriginSlackEventTs: "{reply.message.origin_slack_event.ts}",
                                                  originSlackEventTs: "{reply.origin_slack_event.ts}",
                                                  slackChannelId: "{slack_channel.id}",
-                                                 text: "{reply.text}",
-                                                 time: "{reply.time}"}}) {{
+                                                 text: "{reply.text}"}}) {{
               slackUser {{
                 name
               }}
@@ -242,8 +238,7 @@ class TestCreateUserAndReplyFromSlack:
                                                  messageOriginSlackEventTs: "{reply.message.origin_slack_event.ts}",
                                                  originSlackEventTs: "{reply.origin_slack_event.ts}",
                                                  slackChannelId: "{slack_channel.id}",
-                                                 text: "{reply.text}",
-                                                 time: "{reply.time}"}}) {{
+                                                 text: "{reply.text}"}}) {{
               slackUser {{
                 name
               }}
@@ -294,8 +289,7 @@ class TestCreateUserAndReplyFromSlack:
                                                  messageOriginSlackEventTs: "{reply.message.origin_slack_event.ts}",
                                                  originSlackEventTs: "{reply.origin_slack_event.ts}",
                                                  slackChannelId: "{slack_channel.id}",
-                                                 text: "{reply.text}",
-                                                 time: "{reply.time}"}}) {{
+                                                 text: "{reply.text}"}}) {{
               slackUser {{
                 name
               }}


### PR DESCRIPTION
Removes need for time in input types for messages and replies from Slack.