### PR TITLE
CCP-87: Override message and reply validation based on discussion status

### DIFF
--- a/app/dialogues/models.py
+++ b/app/dialogues/models.py
@@ -51,9 +51,9 @@ def update_discussion_status_from_message(sender, instance=None, created=False, 
 
 @receiver(post_save, sender=Reply)
 def update_discussion_status_from_reply(sender, instance=None, created=False, **kwargs):
-    """Mark discussion as open if message is created.
+    """Mark discussion as open if reply is created.
 
-    Fires on post_save signal for messages. Only marks
+    Fires on post_save signal for replies. Only marks
     a discussion as open if it is currently stale or
     pending closed.
     """

--- a/app/dialogues/validators.py
+++ b/app/dialogues/validators.py
@@ -20,7 +20,7 @@ class MessageValidator(serializers.ModelSerializer):
         fields = ('id', 'text', 'discussion_id', 'author_id', 'time', 'origin_slack_event_id')
 
     def validate(self, data):
-        if Discussion.objects.get(pk=data['discussion_id']).is_closed:
+        if Discussion.objects.get(pk=data.get('discussion').id).is_closed:
             raise serializers.ValidationError('Cannot create message in closed discussion')
         return data
 
@@ -37,6 +37,6 @@ class ReplyValidator(serializers.ModelSerializer):
         fields = ('id', 'text', 'message_id', 'author_id', 'time', 'origin_slack_event_id')
 
     def validate(self, data):
-        if Message.objects.get(pk=data['message_id']).discussion.is_closed:
+        if Message.objects.get(pk=data.get('message').id).discussion.is_closed:
             raise serializers.ValidationError('Cannot create reply to message in closed discussion')
         return data

--- a/app/dialogues/validators.py
+++ b/app/dialogues/validators.py
@@ -19,6 +19,11 @@ class MessageValidator(serializers.ModelSerializer):
         model = Message
         fields = ('id', 'text', 'discussion_id', 'author_id', 'time', 'origin_slack_event_id')
 
+    def validate(self, data):
+        if Discussion.objects.get(pk=data['discussion_id']).is_closed:
+            raise serializers.ValidationError('Cannot create message in closed discussion')
+        return data
+
 
 class ReplyValidator(serializers.ModelSerializer):
     message_id = serializers.PrimaryKeyRelatedField(queryset=Message.objects.all(), source='message')
@@ -30,3 +35,8 @@ class ReplyValidator(serializers.ModelSerializer):
     class Meta:
         model = Reply
         fields = ('id', 'text', 'message_id', 'author_id', 'time', 'origin_slack_event_id')
+
+    def validate(self, data):
+        if Message.objects.get(pk=data['message_id']).discussion.is_closed:
+            raise serializers.ValidationError('Cannot create reply to message in closed discussion')
+        return data

--- a/app/topics/models.py
+++ b/app/topics/models.py
@@ -70,6 +70,10 @@ class Discussion(TimeStampedModel):
         return self.status == DiscussionStatus.CLOSED.value
 
     @property
+    def is_pending_closed(self):
+        return self.status == DiscussionStatus.PENDING_CLOSED.value
+
+    @property
     def is_stale(self):
         return self.status == DiscussionStatus.STALE.value
 
@@ -87,6 +91,11 @@ class Discussion(TimeStampedModel):
         else:
             return False
 
+    @transition(field=status, source=[DiscussionStatus.STALE.value, DiscussionStatus.PENDING_CLOSED.value],
+                target=DiscussionStatus.OPEN.value)
+    def mark_as_open(self):
+        pass
+
     @transition(field=status, source=DiscussionStatus.OPEN.value, target=DiscussionStatus.STALE.value,
                 conditions=[can_mark_as_stale])
     def mark_as_stale(self):
@@ -96,7 +105,6 @@ class Discussion(TimeStampedModel):
     def mark_as_pending_closed(self):
         pass
 
-    # TODO: Check timestamp of last non-bot message and PENDING CLOSED
     @transition(field=status, source='*', target=DiscussionStatus.CLOSED.value)
     def mark_as_closed(self):
         self.time_end = timezone.now()

--- a/tests/func/dialogues/test_create_message.py
+++ b/tests/func/dialogues/test_create_message.py
@@ -1,3 +1,6 @@
+import pytz
+from datetime import datetime, timedelta
+
 import pytest
 
 
@@ -11,7 +14,7 @@ class TestCreateMessage:
 
         mutation = f'''
           mutation {{
-            createMessage(input: {{text: "{message.text}", discussionId: {discussion.id}, authorId: {user.id},
+            createMessage(input: {{text: "{message.text}", discussionId: {discussion.id}, authorId: {message.author.id},
                                    time: "{message.time}"}}) {{
               message {{
                 time
@@ -26,6 +29,29 @@ class TestCreateMessage:
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
+    def test_closed_discussion(self, auth_client, discussion_factory, user_factory, message_factory):
+        discussion = discussion_factory(status='CLOSED')
+        user = user_factory()
+        message = message_factory.build(discussion=discussion, author=user)
+
+        mutation = f'''
+          mutation {{
+            createMessage(input: {{text: "{message.text}", discussionId: {message.discussion.id},
+                                   authorId: {message.author.id}, time: "{message.time}"}}) {{
+              message {{
+                text
+              }}
+            }}
+          }}
+        '''
+        response = auth_client.post('/graphql', {'query': mutation})
+
+        assert response.status_code == 200
+        assert response.json()['data']['createMessage'] is None
+        assert response.json()['errors'][0]['message'] == "{'non_field_errors': ['Cannot create message in closed " \
+                                                          "discussion']}"
+
+    @pytest.mark.django_db
     def test_valid(self, auth_client, discussion_factory, user_factory, message_factory):
         discussion = discussion_factory()
         user = user_factory()
@@ -33,7 +59,7 @@ class TestCreateMessage:
 
         mutation = f'''
           mutation {{
-            createMessage(input: {{text: "{message.text}", discussionId: {discussion.id}, authorId: {user.id},
+            createMessage(input: {{text: "{message.text}", discussionId: {discussion.id}, authorId: {message.author.id},
                                    time: "{message.time}"}}) {{
               message {{
                 text
@@ -45,3 +71,32 @@ class TestCreateMessage:
 
         assert response.status_code == 200
         assert response.json()['data']['createMessage']['message']['text'] == message.text
+
+    @pytest.mark.django_db()
+    def test_marks_discussion_as_open(self, auth_client, discussion_factory, user_factory, message_factory):
+        discussion = discussion_factory()
+        user = user_factory()
+        message_factory(time=datetime.now(tz=pytz.UTC) - timedelta(minutes=31), discussion=discussion)
+        discussion.mark_as_stale()
+        discussion.save()
+
+        message = message_factory.build(discussion=discussion, author=user)
+
+        mutation = f'''
+          mutation {{
+            createMessage(input: {{text: "{message.text}", discussionId: {message.discussion.id},
+                                   authorId: {message.author.id}, time: "{message.time}"}}) {{
+              message {{
+                text
+                discussion {{
+                  status
+                }}
+              }}
+            }}
+          }}
+        '''
+        response = auth_client.post('/graphql', {'query': mutation})
+
+        assert response.status_code == 200
+        assert response.json()['data']['createMessage']['message']['text'] == message.text
+        assert response.json()['data']['createMessage']['message']['discussion']['status'] == 'OPEN'

--- a/tests/func/dialogues/test_create_reply.py
+++ b/tests/func/dialogues/test_create_reply.py
@@ -1,17 +1,21 @@
+import pytz
+from datetime import datetime, timedelta
+
 import pytest
+
+from app.topics.models import Discussion
 
 
 class TestCreateReply:
 
     @pytest.mark.django_db
-    def test_unauthenticated(self, client, message_factory, user_factory, reply_factory):
+    def test_unauthenticated(self, client, message_factory, reply_factory):
         message = message_factory()
-        user = user_factory()
-        reply = reply_factory.build(message=message, author=user)
+        reply = reply_factory.build(message=message)
 
         mutation = f'''
           mutation {{
-            createReply(input: {{text: "{reply.text}", messageId: {message.id}, authorId: {user.id},
+            createReply(input: {{text: "{reply.text}", messageId: {message.id}, authorId: {message.author.id},
                                  time: "{reply.time}"}}) {{
               reply {{
                 text
@@ -25,14 +29,36 @@ class TestCreateReply:
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_valid(self, auth_client, message_factory, user_factory, reply_factory):
-        message = message_factory()
-        user = user_factory()
-        reply = reply_factory.build(message=message, author=user)
+    def test_closed_discussion(self, auth_client, discussion_factory, message_factory, reply_factory):
+        discussion = discussion_factory(status='CLOSED')
+        message = message_factory(discussion=discussion)
+        reply = reply_factory.build(message=message)
 
         mutation = f'''
           mutation {{
-            createReply(input: {{text: "{reply.text}", messageId: {message.id}, authorId: {user.id},
+            createReply(input: {{text: "{reply.text}", messageId: {message.id}, authorId: {message.author.id},
+                                 time: "{reply.time}"}}) {{
+              reply {{
+                text
+              }}
+            }}
+          }}
+        '''
+        response = auth_client.post('/graphql', {'query': mutation})
+
+        assert response.status_code == 200
+        assert response.json()['data']['createReply'] is None
+        assert response.json()['errors'][0]['message'] == "{'non_field_errors': ['Cannot create reply to message in " \
+                                                          "closed discussion']}"
+
+    @pytest.mark.django_db
+    def test_valid(self, auth_client, message_factory, reply_factory):
+        message = message_factory()
+        reply = reply_factory.build(message=message)
+
+        mutation = f'''
+          mutation {{
+            createReply(input: {{text: "{reply.text}", messageId: {message.id}, authorId: {message.author.id},
                                  time: "{reply.time}"}}) {{
               reply {{
                 text
@@ -43,3 +69,33 @@ class TestCreateReply:
         response = auth_client.post('/graphql', {'query': mutation})
 
         assert response.json()['data']['createReply']['reply']['text'] == reply.text
+
+    @pytest.mark.django_db()
+    def test_marks_discussion_as_open(self, auth_client, discussion_factory, message_factory, reply_factory):
+        discussion = discussion_factory()
+        message = message_factory(time=datetime.now(tz=pytz.UTC) - timedelta(minutes=31), discussion=discussion)
+        discussion.mark_as_stale()
+        discussion.save()
+
+        reply = reply_factory.build(message=message)
+
+        mutation = f'''
+          mutation {{
+            createReply(input: {{text: "{reply.text}", messageId: {reply.message.id}, authorId: {message.author.id},
+                                 time: "{reply.time}"}}) {{
+              reply {{
+                text
+                message {{
+                  discussion {{
+                    status
+                  }}
+                }}
+              }}
+            }}
+          }}
+        '''
+        response = auth_client.post('/graphql', {'query': mutation})
+
+        assert response.status_code == 200
+        assert response.json()['data']['createReply']['reply']['text'] == reply.text
+        assert response.json()['data']['createReply']['reply']['message']['discussion']['status'] == 'OPEN'

--- a/tests/func/dialogues/test_create_reply.py
+++ b/tests/func/dialogues/test_create_reply.py
@@ -3,8 +3,6 @@ from datetime import datetime, timedelta
 
 import pytest
 
-from app.topics.models import Discussion
-
 
 class TestCreateReply:
 


### PR DESCRIPTION
- This includes two parts: First, we're now including validating the discussion status on incoming messages and replies. If the dicussion is of status `CLOSED`, then no new replies or messages can be created. Second, we're using `post_save` signals to update the discussion status upon creation of a new message or new reply. This means if a discussion is in `STALE` or `PENDING CLOSED` but a new message or reply comes in, then we update the discussion status to `OPEN`.
- Added tests in the dialogues folder within func that teases out this functionality in the context of mutations.