### PR TITLE
HOTFIX: token auth

### DIFF
--- a/app/api/authorization.py
+++ b/app/api/authorization.py
@@ -1,3 +1,4 @@
+from rest_framework.authentication import TokenAuthentication
 
 
 def check_authorization(resolve_function):
@@ -9,7 +10,10 @@ def check_authorization(resolve_function):
     false, an exception is raised.
     """
     def wrapper(self, info, **kwargs):
-        if not info.context.user.is_authenticated:
+        token_authentication = TokenAuthentication()
+        user, token = token_authentication.authenticate(info.context)
+
+        if not user.is_authenticated:
             raise Exception('Unauthorized')
         return resolve_function(self, info, **kwargs)
     return wrapper

--- a/app/api/authorization.py
+++ b/app/api/authorization.py
@@ -10,10 +10,14 @@ def check_authorization(resolve_function):
     false, an exception is raised.
     """
     def wrapper(self, info, **kwargs):
-        token_authentication = TokenAuthentication()
-        user, token = token_authentication.authenticate(info.context)
+        try:
+            token_authentication = TokenAuthentication()
+            user, token = token_authentication.authenticate(info.context)
+        except TypeError:
+            raise Exception('Unauthorized')
 
         if not user.is_authenticated:
             raise Exception('Unauthorized')
+
         return resolve_function(self, info, **kwargs)
     return wrapper

--- a/app/api/urls.py
+++ b/app/api/urls.py
@@ -8,5 +8,5 @@ from app.api.views import CustomObtainAuthTokenView
 
 urlpatterns = [
     path('auth-token', CustomObtainAuthTokenView.as_view(), name='auth-token'),
-    path('graphql', csrf_exempt(GraphQLView.as_view(graphiql=settings.ENABLE_GRAPHIQL)))
+    path('graphql', csrf_exempt(GraphQLView.as_view(graphiql=settings.ENABLE_GRAPHIQL))),
 ]

--- a/app/api/views.py
+++ b/app/api/views.py
@@ -1,5 +1,4 @@
 from rest_framework.authtoken.views import ObtainAuthToken
-
 from app.api.serializers import CustomAuthTokenSerializer
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 import responses
 from pytest_factoryboy.fixture import register
+from rest_framework.authtoken.models import Token
 from rest_framework.test import APIClient
 from slackclient import SlackClient
 
@@ -39,7 +40,7 @@ register(UserFactory)
 
 
 @pytest.fixture()
-def auth_client(user_factory, transactional_db):
+def auth_client(user_factory):
     """Pytest fixture for authenticated API client
 
     Most of our mutations require authentication. Rather than authenticate
@@ -48,7 +49,8 @@ def auth_client(user_factory, transactional_db):
     """
     user = user_factory()
     client = APIClient()
-    client.force_login(user=user)
+    token = Token.objects.get(user=user)
+    client.credentials(HTTP_AUTHORIZATION=f'Token {token}')
     return client
 
 


### PR DESCRIPTION
I wanted to get a solution up so its not blocking, but I vote we move auth over to GraphQL by v0.2. In any case, judging by some quick reading `info.context.user` seems to only support using Django session auth. JWT isn't supported out of the box (bunch of open-source repos out there that allow JWT for GRaphql, which makes sense). For now, we can use DRF's token authentication manually and then drop it and switch to a token model + graphql mutation / query for 0.2