### PR TITLE
CCP-103: Allow SlackAgentStatus active transition

### DIFF
--- a/app/slack_integration/models.py
+++ b/app/slack_integration/models.py
@@ -53,7 +53,8 @@ class SlackAgent(TimeStampedModel):
             return False
 
     @transition(field=status, source=[SlackAgentStatus.AUTHENTICATED.value, SlackAgentStatus.PAUSED.value,
-                                      SlackAgentStatus.INACTIVE.value], target=SlackAgentStatus.ACTIVE.value,
+                                      SlackAgentStatus.INACTIVE.value, SlackAgentStatus.ACTIVE.value],
+                target=SlackAgentStatus.ACTIVE.value,
                 conditions=[can_activate])
     def activate(self):
         pass


### PR DESCRIPTION
"activate" on Active makes sense to loop back to Active

Useful for when updating TopicChannelId, allows the code to stay the same in cases where we're creating it for the first time (while in authenticated) vs. updating it later (while already active)