### PR TITLE
HOTFIX: resolve django migration conflicts

### DIFF
--- a/app/slack_integration/migrations/0003_auto_20180207_1830.py
+++ b/app/slack_integration/migrations/0003_auto_20180207_1830.py
@@ -6,7 +6,7 @@ from django.db import migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('slack_integration', '0002_auto_20180201_2201'),
+        ('slack_integration', '0003_auto_20180208_1558'),
     ]
 
     operations = [

--- a/app/slack_integration/migrations/0003_auto_20180208_1558.py
+++ b/app/slack_integration/migrations/0003_auto_20180208_1558.py
@@ -6,7 +6,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('slack_integration', '0003_auto_20180207_1830'),
+        ('slack_integration', '0002_auto_20180201_2201'),
     ]
 
     operations = [

--- a/app/slack_integration/migrations/0003_auto_20180208_1558.py
+++ b/app/slack_integration/migrations/0003_auto_20180208_1558.py
@@ -6,7 +6,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('slack_integration', '0002_auto_20180201_2201'),
+        ('slack_integration', '0003_auto_20180207_1830'),
     ]
 
     operations = [


### PR DESCRIPTION
The rename to topics channel conflicted with migration history on previous merge. Resolving them here.