### PR TITLE
HOTFIX: Fix tests from CCP-45 merge

### DIFF
--- a/tests/func/dialogues/test_create_reply.py
+++ b/tests/func/dialogues/test_create_reply.py
@@ -69,13 +69,17 @@ class TestCreateReply:
         assert response.json()['data']['createReply']['reply']['text'] == reply.text
 
     @pytest.mark.django_db()
-    def test_marks_discussion_as_open(self, auth_client, discussion_factory, message_factory, reply_factory):
+    def test_marks_discussion_as_open(self, auth_client, discussion_factory, user_factory, message_factory,
+                                      reply_factory):
+        message_author = user_factory(is_bot=False)
+        reply_author = user_factory(is_bot=False)
         discussion = discussion_factory()
-        message = message_factory(time=datetime.now(tz=pytz.UTC) - timedelta(minutes=31), discussion=discussion)
+        message = message_factory(time=datetime.now(tz=pytz.UTC) - timedelta(minutes=31), discussion=discussion,
+                                  author=message_author)
         discussion.mark_as_stale()
         discussion.save()
 
-        reply = reply_factory.build(message=message)
+        reply = reply_factory.build(message=message, author=reply_author)
 
         mutation = f'''
           mutation {{

--- a/tests/func/slack_integration/test_attempt_slack_installation.py
+++ b/tests/func/slack_integration/test_attempt_slack_installation.py
@@ -1,5 +1,4 @@
 import pytest
-import requests
 
 
 class TestAttemptSlackInstallation:


### PR DESCRIPTION
- There's a general runtime error that occurs if the user_factory generates a user where `is_bot=True`. This means that any message sent by such user is not factored into the discussion monitoring logic. Went and changed this in create_reply and create_message tests.
- Had a PEP issue from resolving a merge conflict