### PR TITLE
CCP-116: Use SSL/HTTPS

### DIFF
--- a/.ebextensions/django.config
+++ b/.ebextensions/django.config
@@ -2,28 +2,24 @@ container_commands:
   01_wsgi_pass_authorization:
     command: >
       # Turn on WSGIPassAuthorization if not found
-      if ! grep -Fxq "WSGIPassAuthorization On" /etc/httpd/conf.d/wsgi.conf
-          then
+      if ! grep -Fxq "WSGIPassAuthorization On" /etc/httpd/conf.d/wsgi.conf; then
           echo "WSGIPassAuthorization On" | tee -a /opt/python/etc/supervisord.conf
       fi
 
   02_wsgi_rewrite:
     command: >
       # Turn on RewriteEngine if not found
-      if ! grep -Fxq "RewriteEngine On" /etc/httpd/conf.d/wsgi.conf
-          then
+      if ! grep -Fxq "RewriteEngine On" /etc/httpd/conf.d/wsgi.conf; then
           echo "RewriteEngine On" | tee -a /opt/python/etc/supervisord.conf
       fi
 
       # Add https RewriteCond if not found
-      if ! grep -Fxq "RewriteCond %{HTTP:X-Forwarded-Proto} !https" /etc/httpd/conf.d/wsgi.conf
-          then
+      if ! grep -Fxq "RewriteCond %{HTTP:X-Forwarded-Proto} !https" /etc/httpd/conf.d/wsgi.conf; then
           echo "RewriteCond %{HTTP:X-Forwarded-Proto} !https" | tee -a /opt/python/etc/supervisord.conf
       fi
 
       # Add https RewriteRule if not found
-      if ! grep -Fxq "RewriteRule . https://%{SERVER_NAME} [L,R=301]" /etc/httpd/conf.d/wsgi.conf
-          then
+      if ! grep -Fxq "RewriteRule . https://%{SERVER_NAME} [L,R=301]" /etc/httpd/conf.d/wsgi.conf; then
           echo "RewriteRule . https://%{SERVER_NAME} [L,R=301]" | tee -a /opt/python/etc/supervisord.conf
       fi
 

--- a/.ebextensions/django.config
+++ b/.ebextensions/django.config
@@ -1,7 +1,6 @@
 container_commands:
   01_wsgi_pass_authorization:
     command: >
-      # Turn on WSGIPassAuthorization if not found
       if ! grep -Fxq "WSGIPassAuthorization On" /etc/httpd/conf.d/wsgi.conf; then
           echo "WSGIPassAuthorization On" | tee -a /etc/httpd/conf.d/wsgi.conf
       fi

--- a/.ebextensions/django.config
+++ b/.ebextensions/django.config
@@ -7,17 +7,14 @@ container_commands:
 
   02_wsgi_rewrite:
     command: >
-      # Turn on RewriteEngine if not found
       if ! grep -Fxq "RewriteEngine On" /etc/httpd/conf.d/wsgi.conf; then
           echo "RewriteEngine On" | tee -a /etc/httpd/conf.d/wsgi.conf
       fi
 
-      # Add https RewriteCond if not found
       if ! grep -Fxq "RewriteCond %{HTTP:X-Forwarded-Proto} !https" /etc/httpd/conf.d/wsgi.conf; then
           echo "RewriteCond %{HTTP:X-Forwarded-Proto} !https" | tee -a /etc/httpd/conf.d/wsgi.conf
       fi
 
-      # Add https RewriteRule if not found
       if ! grep -Fxq "RewriteRule . https://%{SERVER_NAME} [L,R=301]" /etc/httpd/conf.d/wsgi.conf; then
           echo "RewriteRule . https://%{SERVER_NAME} [L,R=301]" | tee -a /etc/httpd/conf.d/wsgi.conf
       fi

--- a/.ebextensions/django.config
+++ b/.ebextensions/django.config
@@ -1,4 +1,7 @@
 container_commands:
+  00_echo:
+    command: "pwd"
+
   01_wsgi_pass_authorization:
     command: >
       if ! grep -Fxq "WSGIPassAuthorization On" /etc/httpd/conf.d/wsgi.conf; then

--- a/.ebextensions/django.config
+++ b/.ebextensions/django.config
@@ -3,24 +3,24 @@ container_commands:
     command: >
       # Turn on WSGIPassAuthorization if not found
       if ! grep -Fxq "WSGIPassAuthorization On" /etc/httpd/conf.d/wsgi.conf; then
-          echo "WSGIPassAuthorization On" | tee -a /opt/python/etc/supervisord.conf
+          echo "WSGIPassAuthorization On" | tee -a /etc/httpd/conf.d/wsgi.conf
       fi
 
   02_wsgi_rewrite:
     command: >
       # Turn on RewriteEngine if not found
       if ! grep -Fxq "RewriteEngine On" /etc/httpd/conf.d/wsgi.conf; then
-          echo "RewriteEngine On" | tee -a /opt/python/etc/supervisord.conf
+          echo "RewriteEngine On" | tee -a /etc/httpd/conf.d/wsgi.conf
       fi
 
       # Add https RewriteCond if not found
       if ! grep -Fxq "RewriteCond %{HTTP:X-Forwarded-Proto} !https" /etc/httpd/conf.d/wsgi.conf; then
-          echo "RewriteCond %{HTTP:X-Forwarded-Proto} !https" | tee -a /opt/python/etc/supervisord.conf
+          echo "RewriteCond %{HTTP:X-Forwarded-Proto} !https" | tee -a /etc/httpd/conf.d/wsgi.conf
       fi
 
       # Add https RewriteRule if not found
       if ! grep -Fxq "RewriteRule . https://%{SERVER_NAME} [L,R=301]" /etc/httpd/conf.d/wsgi.conf; then
-          echo "RewriteRule . https://%{SERVER_NAME} [L,R=301]" | tee -a /opt/python/etc/supervisord.conf
+          echo "RewriteRule . https://%{SERVER_NAME} [L,R=301]" | tee -a /etc/httpd/conf.d/wsgi.conf
       fi
 
   03_migrate:

--- a/.ebextensions/django.config
+++ b/.ebextensions/django.config
@@ -1,8 +1,36 @@
 container_commands:
-  01_migrate:
+  01_wsgi_pass_authorization:
+    command: >
+      # Turn on WSGIPassAuthorization if not found
+      if ! grep -Fxq "WSGIPassAuthorization On" /etc/httpd/conf.d/wsgi.conf
+          then
+          echo "WSGIPassAuthorization On" | tee -a /opt/python/etc/supervisord.conf
+      fi
+
+  02_wsgi_rewrite:
+    command: >
+      # Turn on RewriteEngine if not found
+      if ! grep -Fxq "RewriteEngine On" /etc/httpd/conf.d/wsgi.conf
+        then
+        echo "RewriteEngine On" | tee -a /opt/python/etc/supervisord.conf
+      fi
+
+      # Add https RewriteCond if not found
+      if ! grep -Fxq "RewriteCond %{HTTP:X-Forwarded-Proto} !https" /etc/httpd/conf.d/wsgi.conf
+        then
+        echo "RewriteCond %{HTTP:X-Forwarded-Proto} !https" | tee -a /opt/python/etc/supervisord.conf
+      fi
+
+      # Add https RewriteRule if not found
+      if ! grep -Fxq "RewriteRule . https://%{SERVER_NAME} [L,R=301]" /etc/httpd/conf.d/wsgi.conf
+        then
+        echo "RewriteRule . https://%{SERVER_NAME} [L,R=301]" | tee -a /opt/python/etc/supervisord.conf
+      fi
+
+  03_migrate:
     command: "python manage.py migrate"
 
-  02_collectstatic:
+  04_collectstatic:
     command: "python manage.py collectstatic --noinput"
 
 

--- a/.ebextensions/django.config
+++ b/.ebextensions/django.config
@@ -1,25 +1,25 @@
 container_commands:
-  00_echo:
-    command: "pwd"
+  00_copy_wsgi:
+    command: "cp /etc/httpd/conf.d/wsgi.conf ../"
 
   01_wsgi_pass_authorization:
     command: >
-      if ! grep -Fxq "WSGIPassAuthorization On" /etc/httpd/conf.d/wsgi.conf; then
-          echo "WSGIPassAuthorization On" | tee -a /etc/httpd/conf.d/wsgi.conf
+      if ! grep -Fxq "WSGIPassAuthorization On" ../wsgi.conf; then
+          echo "WSGIPassAuthorization On" | tee -a ../wsgi.conf
       fi
 
   02_wsgi_rewrite:
     command: >
-      if ! grep -Fxq "RewriteEngine On" /etc/httpd/conf.d/wsgi.conf; then
-          echo "RewriteEngine On" | tee -a /etc/httpd/conf.d/wsgi.conf
+      if ! grep -Fxq "RewriteEngine On" ../wsgi.conf; then
+          echo "RewriteEngine On" | tee -a ../wsgi.conf
       fi
 
-      if ! grep -Fxq "RewriteCond %{HTTP:X-Forwarded-Proto} !https" /etc/httpd/conf.d/wsgi.conf; then
-          echo "RewriteCond %{HTTP:X-Forwarded-Proto} !https" | tee -a /etc/httpd/conf.d/wsgi.conf
+      if ! grep -Fxq "RewriteCond %{HTTP:X-Forwarded-Proto} !https" ../wsgi.conf; then
+          echo "RewriteCond %{HTTP:X-Forwarded-Proto} !https" | tee -a ../wsgi.conf
       fi
 
-      if ! grep -Fxq "RewriteRule . https://%{SERVER_NAME} [L,R=301]" /etc/httpd/conf.d/wsgi.conf; then
-          echo "RewriteRule . https://%{SERVER_NAME} [L,R=301]" | tee -a /etc/httpd/conf.d/wsgi.conf
+      if ! grep -Fxq "RewriteRule . https://%{SERVER_NAME} [L,R=301]" ../wsgi.conf; then
+          echo "RewriteRule . https://%{SERVER_NAME} [L,R=301]" | tee -a ../wsgi.conf
       fi
 
   03_migrate:

--- a/.ebextensions/django.config
+++ b/.ebextensions/django.config
@@ -11,20 +11,20 @@ container_commands:
     command: >
       # Turn on RewriteEngine if not found
       if ! grep -Fxq "RewriteEngine On" /etc/httpd/conf.d/wsgi.conf
-        then
-        echo "RewriteEngine On" | tee -a /opt/python/etc/supervisord.conf
+          then
+          echo "RewriteEngine On" | tee -a /opt/python/etc/supervisord.conf
       fi
 
       # Add https RewriteCond if not found
       if ! grep -Fxq "RewriteCond %{HTTP:X-Forwarded-Proto} !https" /etc/httpd/conf.d/wsgi.conf
-        then
-        echo "RewriteCond %{HTTP:X-Forwarded-Proto} !https" | tee -a /opt/python/etc/supervisord.conf
+          then
+          echo "RewriteCond %{HTTP:X-Forwarded-Proto} !https" | tee -a /opt/python/etc/supervisord.conf
       fi
 
       # Add https RewriteRule if not found
       if ! grep -Fxq "RewriteRule . https://%{SERVER_NAME} [L,R=301]" /etc/httpd/conf.d/wsgi.conf
-        then
-        echo "RewriteRule . https://%{SERVER_NAME} [L,R=301]" | tee -a /opt/python/etc/supervisord.conf
+          then
+          echo "RewriteRule . https://%{SERVER_NAME} [L,R=301]" | tee -a /opt/python/etc/supervisord.conf
       fi
 
   03_migrate:

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -19,6 +19,11 @@ DATABASES = {
 }
 
 ENABLE_GRAPHIQL = False
+
+# SSL/HTTPS
+# https://docs.djangoproject.com/en/2.0/topics/security/
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+SECURE_SSL_REDIRECT = True
 CSRF_COOKIE_SECURE = True
 
 # Slack credentials

--- a/config/settings/staging.py
+++ b/config/settings/staging.py
@@ -2,7 +2,7 @@ import os
 
 # Prevent HTTP Host header attacks
 # https://docs.djangoproject.com/en/2.0/ref/settings/#allowed-hosts
-ALLOWED_HOSTS = ['portal-staging.us-east-1.elasticbeanstalk.com']
+ALLOWED_HOSTS = ['portal-staging.us-east-1.elasticbeanstalk.com', 'staging.codeclippy.com']
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 

--- a/config/settings/staging.py
+++ b/config/settings/staging.py
@@ -23,6 +23,11 @@ DATABASES = {
 }
 
 ENABLE_GRAPHIQL = True
+
+# SSL/HTTPS
+# https://docs.djangoproject.com/en/2.0/topics/security/
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+SECURE_SSL_REDIRECT = True
 CSRF_COOKIE_SECURE = True
 
 # Slack credentials

--- a/tests/func/slack_integration/test_attempt_slack_installation.py
+++ b/tests/func/slack_integration/test_attempt_slack_installation.py
@@ -1,5 +1,4 @@
 import pytest
-import requests
 
 
 class TestAttemptSlackInstallation:


### PR DESCRIPTION
- Turn on WSGIPassAuthorization so that the WSGI application handles authorization instead of Apache. This allows us to see the X_Forwarded_Proto header (which is added by the load balancer) as well as other authorization headers.
- Turn on the RewriteEngine, which allows us to have RewriteRules which follow a perl regex and rewrite the routing to another url (in our case HTTP -> HTTPS)
- Add the staging domain to the ALLOWED_HOSTS