### PR TITLE
CCS-113: Dockerfile 

### DIFF
--- a/config/settings/development.py
+++ b/config/settings/development.py
@@ -1,6 +1,10 @@
 import os
 import json
 
+# Prevent HTTP Host header attacks
+# https://docs.djangoproject.com/en/2.0/ref/settings/#allowed-hosts
+ALLOWED_HOSTS = ['docker.for.mac.localhost']
+
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 DEBUG = True


### PR DESCRIPTION
- Meat of ticket is on CCS with this exception which allows docker containers to resolve the host machine's localhost.