### PR TITLE
HOTFIX: Include day difference in minutes_since_last_non_bot_message

### DIFF
--- a/app/topics/models.py
+++ b/app/topics/models.py
@@ -60,8 +60,10 @@ class Discussion(TimeStampedModel):
 
     @property
     def minutes_since_last_non_bot_message(self):
-        time_delta = timezone.now() - self.datetime_of_last_non_bot_message
-        minutes = round(time_delta.seconds / 60, 2)
+        minutes = (
+                round(((timezone.now() - self.datetime_of_last_non_bot_message).seconds / 60), 2) +
+                ((timezone.now() - self.datetime_of_last_non_bot_message).days * 24 * 60)
+        )
         return minutes
 
     @property

--- a/tests/unit/test_discussion_model.py
+++ b/tests/unit/test_discussion_model.py
@@ -9,9 +9,9 @@ class TestDiscussionModel:
     @pytest.mark.django_db
     def test_minutes_since_last_non_bot_message(self, user_factory, message_factory, discussion_factory):
         """
-        Given: The database has been created.
-        When: A user is created without an email.
-        Then: No constraint is violated.
+        Given: A discussion's last non-bot message is over a day old.
+        When: The minutes_since_last_non_bot_message is computed.
+        Then: The minutes > 1440.
         """
         discussion = discussion_factory()
         user = user_factory(is_bot=False)

--- a/tests/unit/test_discussion_model.py
+++ b/tests/unit/test_discussion_model.py
@@ -18,4 +18,4 @@ class TestDiscussionModel:
         message_time = datetime.now(tz=pytz.UTC) - timedelta(days=1, minutes=30)
         message_factory(author=user, time=message_time, discussion=discussion)
 
-        assert discussion.minutes_since_last_non_bot_message >= (60*24 + 30)
+        assert discussion.minutes_since_last_non_bot_message >= ((60*24) + 30)

--- a/tests/unit/test_discussion_model.py
+++ b/tests/unit/test_discussion_model.py
@@ -1,0 +1,21 @@
+import pytz
+from datetime import datetime, timedelta
+
+import pytest
+
+
+class TestDiscussionModel:
+
+    @pytest.mark.django_db
+    def test_minutes_since_last_non_bot_message(self, user_factory, message_factory, discussion_factory):
+        """
+        Given: The database has been created.
+        When: A user is created without an email.
+        Then: No constraint is violated.
+        """
+        discussion = discussion_factory()
+        user = user_factory(is_bot=False)
+        message_time = datetime.now(tz=pytz.UTC) - timedelta(days=1, minutes=30)
+        message_factory(author=user, time=message_time, discussion=discussion)
+
+        assert discussion.minutes_since_last_non_bot_message >= (60*24 + 30)

--- a/tests/unit/test_discussion_model.py
+++ b/tests/unit/test_discussion_model.py
@@ -18,4 +18,4 @@ class TestDiscussionModel:
         message_time = datetime.now(tz=pytz.UTC) - timedelta(days=1, minutes=30)
         message_factory(author=user, time=message_time, discussion=discussion)
 
-        assert discussion.minutes_since_last_non_bot_message >= ((60*24) + 30)
+        assert discussion.minutes_since_last_non_bot_message >= ((60 * 24) + 30)


### PR DESCRIPTION
- Expected behavior: A discussion's minutes_since_last_non_bot_message should be 1440 at the 24 hour mark.
- Current behavior: A discussion's minutes_since_last_non_bot_message is reset to 0 at the 24 hour mark.

This error was revealed by shift to 24 hours for a stale message. The underlying cause was that a timedelta's seconds attribute only takes into account the difference in seconds between the times not the days. To account for days, they must be converted to minutes separately and added to the total delta.