### PR TITLE
API-130: Include Celery logs in Cloudwatch

### DIFF
--- a/.ebextensions/03_celery.config
+++ b/.ebextensions/03_celery.config
@@ -64,7 +64,6 @@ files:
 container_commands:
   00_touch_celery_logs:
     command: |
-      whoami
       touch /opt/python/log/celerybeat.log
       touch /opt/python/log/celeryworker.log
 

--- a/.ebextensions/03_celery.config
+++ b/.ebextensions/03_celery.config
@@ -1,4 +1,19 @@
 files:
+  "/etc/awslogs/config/celery.conf":
+    mode: "000755"
+    owner: root
+    group: root
+    content: |
+      [/opt/python/log/celerybeat.log]
+      log_group_name = `{"Fn::Join":["/", ["/aws/elasticbeanstalk", { "Ref":"AWSEBEnvironmentName" }, "opt/python/log/celerybeat.log"]]}`
+      log_stream_name = {instance_id}
+      file=/opt/python/log/celerybeat.log
+
+      [/opt/python/log/celeryworker.log]
+      log_group_name = `{"Fn::Join":["/", ["/aws/elasticbeanstalk", { "Ref":"AWSEBEnvironmentName" }, "opt/python/log/celeryworker.log"]]}`
+      log_stream_name = {instance_id}
+      file=/opt/python/log/celeryworker.log
+
   "/opt/python/etc/celery.conf":
     mode: "000755"
     owner: root
@@ -16,8 +31,8 @@ files:
       directory=/opt/python/current/app
       user=nobody
       numprocs=1
-      stdout_logfile=/var/log/celerybeat.log
-      stderr_logfile=/var/log/celerybeat.log
+      stdout_logfile=/opt/python/log/celerybeat.log
+      stderr_logfile=/opt/python/log/celerybeat.log
       autostart=true
       autorestart=true
       startsecs=10
@@ -37,8 +52,8 @@ files:
       directory=/opt/python/current/app
       user=nobody
       numprocs=1
-      stdout_logfile=/var/log/celeryworker.log
-      stderr_logfile=/var/log/celeryworker.log
+      stdout_logfile=/opt/python/log/celeryworker.log
+      stderr_logfile=/opt/python/log/celeryworker.log
       autostart=true
       autorestart=true
       startsecs=10
@@ -49,8 +64,9 @@ files:
 container_commands:
   00_touch_celery_logs:
     command: |
-      touch /var/log/celerybeat.log
-      touch /var/log/celeryworker.log
+      whoami
+      touch /opt/python/log/celerybeat.log
+      touch /opt/python/log/celeryworker.log
 
   01_add_celery_to_supervisord:
     command: |

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -16,10 +16,12 @@ if os.environ.get('ENVIRONMENT') == 'PROD':
     from config.settings.production import *
 elif os.environ.get('ENVIRONMENT') == 'STAGING':
     from config.settings.staging import *
+elif os.environ.get('ENVIRONMENT') == 'DEVELOPMENT':
+    from config.settings.dev
 elif os.environ.get('ENVIRONMENT') == 'TEST':
     from config.settings.testing import *
 else:
-    from config.settings.development import *
+    from config.settings.local import *
 
 # Release version
 VERSION = '0.1.0'

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -17,7 +17,7 @@ if os.environ.get('ENVIRONMENT') == 'PROD':
 elif os.environ.get('ENVIRONMENT') == 'STAGING':
     from config.settings.staging import *
 elif os.environ.get('ENVIRONMENT') == 'DEVELOPMENT':
-    from config.settings.dev
+    from config.settings.development import *
 elif os.environ.get('ENVIRONMENT') == 'TEST':
     from config.settings.testing import *
 else:

--- a/config/settings/development.py
+++ b/config/settings/development.py
@@ -1,9 +1,8 @@
 import os
-import json
 
 # Prevent HTTP Host header attacks
 # https://docs.djangoproject.com/en/2.0/ref/settings/#allowed-hosts
-ALLOWED_HOSTS = ['docker.for.mac.localhost', 'localhost']
+ALLOWED_HOSTS = ['strand-api-development.us-east-1.elasticbeanstalk.com', 'development.api.trystrand.com']
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -11,40 +10,55 @@ DEBUG = True
 
 # Database
 # https://docs.djangoproject.com/en/2.0/ref/settings/#databases
-DB_CREDENTIALS = json.load(open(os.path.join(BASE_DIR, 'db.config.json'), 'r'))
-
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
-        'NAME': DB_CREDENTIALS['NAME'],
-        'USER': DB_CREDENTIALS['USER'],
-        'PASSWORD': DB_CREDENTIALS['PASSWORD'],
-        'HOST': DB_CREDENTIALS['HOST'],
-        'PORT': DB_CREDENTIALS['PORT']
+        'NAME': os.environ['DB_NAME'],
+        'USER': os.environ['DB_USER'],
+        'PASSWORD': os.environ['DB_PASSWORD'],
+        'HOST': os.environ['DB_HOST'],
+        'PORT': os.environ['DB_PORT']
     }
 }
 
 ENABLE_GRAPHIQL = True
-CSRF_COOKIE_SECURE = False
+
+# SSL/HTTPS
+# https://docs.djangoproject.com/en/2.0/topics/security/
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+SECURE_SSL_REDIRECT = True
+CSRF_COOKIE_SECURE = True
 
 # Slack credentials
-SLACK_CLIENT_SECRET = '6d78f8dc3bb99ce00bb172ef662a8389'
+SLACK_CLIENT_SECRET = os.environ['SLACK_CLIENT_SECRET']
 
 # Celery
-CELERY_BROKER_URL = 'redis://localhost:6379'
+CELERY_BROKER_URL = os.environ['CELERY_BROKER_URL']
 
-# Discussion settings
-MIN_UNTIL_STALE = 30.0
-AUTO_CLOSE_DELAY = 60
+# Discussion Auto-Close Delay
+MIN_UNTIL_STALE = float(os.environ['MIN_UNTIL_STALE'])
+AUTO_CLOSE_DELAY = int(os.environ['AUTO_CLOSE_DELAY'])
 
-SLACK_APP_VERIFICATION_TOKEN = 'anoTH3rRANDoMCOmbo'
-SLACK_APP_STALE_DISCUSSION_ENDPOINT = 'https://localhost:4000/portal/discussions/stale'
-SLACK_APP_AUTO_CLOSED_DISCUSSION_ENDPOINT = 'http://localhost:4000/portal/discussions/closed'
-SLACK_APP_SLACK_AGENT_ENDPOINT = 'http://localhost:4000/portal/slackagents'
+# Slack App Verification Token
+SLACK_APP_VERIFICATION_TOKEN = os.environ['SLACK_APP_VERIFICATION_TOKEN']
+SLACK_APP_STALE_DISCUSSION_ENDPOINT = os.environ['SLACK_APP_STALE_DISCUSSION_ENDPOINT']
+SLACK_APP_AUTO_CLOSED_DISCUSSION_ENDPOINT = os.environ['SLACK_APP_AUTO_CLOSED_DISCUSSION_ENDPOINT']
+SLACK_APP_SLACK_AGENT_ENDPOINT = os.environ['SLACK_APP_SLACK_AGENT_ENDPOINT']
+
+# django-storages
+# http://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html
+AWS_STORAGE_BUCKET_NAME = os.environ['AWS_STORAGE_BUCKET_NAME']
+AWS_S3_CUSTOM_DOMAIN = f'{AWS_STORAGE_BUCKET_NAME}.s3.amazonaws.com'
+AWS_S3_OBJECT_PARAMETERS = {
+    'CacheControl': 'max-age=86400',
+}
+AWS_LOCATION = 'static'
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/2.0/howto/static-files/
-STATIC_URL = '/static/'
+
+STATIC_URL = f'https://{AWS_S3_CUSTOM_DOMAIN}/{AWS_LOCATION}/'
+STATICFILES_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
 
 # CORS
 # https://github.com/ottoyiu/django-cors-headers

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -1,0 +1,52 @@
+import os
+import json
+
+# Prevent HTTP Host header attacks
+# https://docs.djangoproject.com/en/2.0/ref/settings/#allowed-hosts
+ALLOWED_HOSTS = ['docker.for.mac.localhost', 'localhost']
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+DEBUG = True
+
+# Database
+# https://docs.djangoproject.com/en/2.0/ref/settings/#databases
+DB_CREDENTIALS = json.load(open(os.path.join(BASE_DIR, 'db.config.json'), 'r'))
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': DB_CREDENTIALS['NAME'],
+        'USER': DB_CREDENTIALS['USER'],
+        'PASSWORD': DB_CREDENTIALS['PASSWORD'],
+        'HOST': DB_CREDENTIALS['HOST'],
+        'PORT': DB_CREDENTIALS['PORT']
+    }
+}
+
+ENABLE_GRAPHIQL = True
+CSRF_COOKIE_SECURE = False
+
+# Slack credentials
+SLACK_CLIENT_SECRET = '6d78f8dc3bb99ce00bb172ef662a8389'
+
+# Celery
+CELERY_BROKER_URL = 'redis://localhost:6379'
+
+# Discussion settings
+MIN_UNTIL_STALE = 30.0
+AUTO_CLOSE_DELAY = 60
+
+SLACK_APP_VERIFICATION_TOKEN = 'anoTH3rRANDoMCOmbo'
+SLACK_APP_STALE_DISCUSSION_ENDPOINT = 'https://localhost:4000/portal/discussions/stale'
+SLACK_APP_AUTO_CLOSED_DISCUSSION_ENDPOINT = 'http://localhost:4000/portal/discussions/closed'
+SLACK_APP_SLACK_AGENT_ENDPOINT = 'http://localhost:4000/portal/slackagents'
+
+# Static files (CSS, JavaScript, Images)
+# https://docs.djangoproject.com/en/2.0/howto/static-files/
+STATIC_URL = '/static/'
+
+# CORS
+# https://github.com/ottoyiu/django-cors-headers
+CORS_ORIGIN_ALLOW_ALL = True
+CORS_PREFLIGHT_MAX_AGE = 0


### PR DESCRIPTION
- Adds a custom config to the `awslogs` folder that specifies an additional logstream that will carry our logs for celerybeat and celeryworker. Format for this config file can be found [here](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AgentReference.html#agent-configuration-file).
- Separately in Terraform, I added custom inline policies for both IAM roles that give the instances for API-staging and API-production access to create log streams / push batch events / etc.
- Differentiated between `development` and `local`. I ended up creating the necessary `development` resources in Terraform for the API. The reason being that I imagine will want to test/develop in AWS remotely as we bolster more and more of the API (whether that's using Elasticache for messages or the upcoming tickets for celery stability / WSGI overwrite prevention).