### PR TITLE
API-128: Prevent WSGI overwrite

### DIFF
--- a/.ebextensions/02_django.config
+++ b/.ebextensions/02_django.config
@@ -1,3 +1,27 @@
+files:
+  "/opt/elasticbeanstalk/hooks/configdeploy/pre/99_wsgi.sh"
+    mode: "000755"
+    owner: root
+    group: root
+    content: |
+      wsgi_path=/etc/httpd/conf.d/wsgi.conf
+      if ! grep -Fxq "WSGIPassAuthorization On" $wsgi_path; then
+          echo "WSGIPassAuthorization On" | tee -a $wsgi_path
+      fi
+
+      if ! grep -Fxq "RewriteEngine On" $wsgi_path; then
+          echo "RewriteEngine On" | tee -a $wsgi_path
+      fi
+
+      if ! grep -Fxq "RewriteCond %{HTTP:X-Forwarded-Proto} !https" $wsgi_path; then
+          echo "RewriteCond %{HTTP:X-Forwarded-Proto} !https" | tee -a $wsgi_path
+      fi
+
+      if ! grep -Fxq "RewriteRule . https://%{SERVER_NAME} [L,R=301]" $wsgi_path; then
+          echo "RewriteRule . https://%{SERVER_NAME} [L,R=301]" | tee -a $wsgi_path
+      fi
+
+
 container_commands:
   00_copy_wsgi:
     command: "cp /etc/httpd/conf.d/wsgi.conf ../"

--- a/.ebextensions/02_django.config
+++ b/.ebextensions/02_django.config
@@ -1,5 +1,5 @@
 files:
-  "/opt/elasticbeanstalk/hooks/configdeploy/pre/99_wsgi.sh"
+  "/opt/elasticbeanstalk/hooks/configdeploy/pre/99_wsgi.sh":
     mode: "000755"
     owner: root
     group: root

--- a/.ebextensions/02_django.config
+++ b/.ebextensions/02_django.config
@@ -1,11 +1,11 @@
 files:
-  "/opt/elasticbeanstalk/hooks/configdeploy/pre/99_wsgi.sh":
+  "/opt/elasticbeanstalk/hooks/configdeploy/post/99_wsgi.sh":
     mode: "000755"
     owner: root
     group: root
     content: |
-      echo "Updating WSGI..."
-      wsgi_path=/etc/httpd/conf.d/wsgi.conf
+      wsgi_path=`/opt/elasticbeanstalk/bin/get-config container -k wsgi_staging_config`
+
       if ! grep -Fxq "WSGIPassAuthorization On" $wsgi_path; then
           echo "Setting WSGIPassAuthorization..."
           echo "WSGIPassAuthorization On" | tee -a $wsgi_path

--- a/.ebextensions/02_django.config
+++ b/.ebextensions/02_django.config
@@ -4,20 +4,25 @@ files:
     owner: root
     group: root
     content: |
+      echo "Updating WSGI..."
       wsgi_path=/etc/httpd/conf.d/wsgi.conf
       if ! grep -Fxq "WSGIPassAuthorization On" $wsgi_path; then
+          echo "Setting WSGIPassAuthorization..."
           echo "WSGIPassAuthorization On" | tee -a $wsgi_path
       fi
 
       if ! grep -Fxq "RewriteEngine On" $wsgi_path; then
+          echo "Setting RewriteEngine..."
           echo "RewriteEngine On" | tee -a $wsgi_path
       fi
 
       if ! grep -Fxq "RewriteCond %{HTTP:X-Forwarded-Proto} !https" $wsgi_path; then
+          echo "Setting RewriteCond..."
           echo "RewriteCond %{HTTP:X-Forwarded-Proto} !https" | tee -a $wsgi_path
       fi
 
       if ! grep -Fxq "RewriteRule . https://%{SERVER_NAME} [L,R=301]" $wsgi_path; then
+          echo "Setting RewriteRule..."
           echo "RewriteRule . https://%{SERVER_NAME} [L,R=301]" | tee -a $wsgi_path
       fi
 

--- a/.ebextensions/02_django.config
+++ b/.ebextensions/02_django.config
@@ -1,5 +1,5 @@
 files:
-  "/opt/elasticbeanstalk/hooks/configdeploy/post/99_wsgi.sh":
+  "/opt/elasticbeanstalk/hooks/configdeploy/pre/99_wsgi.sh":
     mode: "000755"
     owner: root
     group: root


### PR DESCRIPTION
- Elasticbeanstalk has two types of deployment: *app deployment* and *config deployment* (new environmental variables, static aliases, etc).
- There are also two main phases of any type of deployment: pre and post. `Pre` is when the app is "ondeck" for deployment and `post` is when the app is deployed. 
- The `container_commands` are only executed during app deployment (after the 'pre' phase but before the 'post' phase during what is called the 'build' stage).
- What makes this problematic is that during the `pre` phase of config deployment, a new WSGI config file is loaded from a template in the "ondeck" folder and effectively overwrites our changes from the `container_commands` that run during app deployment.

To fix this, we can create a bash script that runs at the end of the pre phase of config deployment (we tell it to run at the end by using `99` as the file prefix). This script gets the path to the ondeck WSGI config file template and makes the same edits we do to that file during app deployment!