### PR TITLE
API-129: Stabilize Celery Processes

### DIFF
--- a/.ebextensions/03_celery.config
+++ b/.ebextensions/03_celery.config
@@ -82,8 +82,8 @@ files:
       supervisorctl -c /opt/python/etc/supervisord.conf update
 
       # Stop celery processes
-      supervisorctl -c /opt/python/etc/supervisord.conf stop celerybeat
-      supervisorctl -c /opt/python/etc/supervisord.conf stop celeryworker
+      supervisorctl -c /opt/python/etc/supervisord.conf stop celerybeat || true
+      supervisorctl -c /opt/python/etc/supervisord.conf stop celeryworker || true
       ps auxww | grep 'celery' | awk '{print $2}' | sudo xargs kill -9 || true
 
       # Remove pid files

--- a/.ebextensions/03_celery.config
+++ b/.ebextensions/03_celery.config
@@ -25,7 +25,7 @@ files:
 
       [program:celerybeat]
       ; Load environmental variables and start beat
-      command=/bin/bash -c "source /opt/python/current/env && /opt/python/run/venv/bin/celery beat -A app --pidfile=/tmp/celerybeat.pid"
+      command=/bin/bash -c "source /opt/python/current/env && /opt/python/run/venv/bin/celery beat -A app"
 
       ; Full path to Django app
       directory=/opt/python/current/app
@@ -46,7 +46,7 @@ files:
 
       [program:celeryworker]
       ; Load environmental variables and start worker
-      command=/bin/bash -c "source /opt/python/current/env && /opt/python/run/venv/bin/celery -A app worker -l info --pidfile=/tmp/celeryworker.pid"
+      command=/bin/bash -c "source /opt/python/current/env && /opt/python/run/venv/bin/celery -A app worker -l info"
 
       ; Full path to Django app
       directory=/opt/python/current/app
@@ -69,8 +69,7 @@ container_commands:
 
   01_add_celery_to_supervisord:
     command: |
-      if ! grep -Fxq "[include]" /opt/python/etc/supervisord.conf
-          then
+      if ! grep -Fxq "[include]" /opt/python/etc/supervisord.conf; then
           echo "" | tee -a /opt/python/etc/supervisord.conf
           echo "[include]" | tee -a /opt/python/etc/supervisord.conf
           echo "files: celery.conf" | tee -a /opt/python/etc/supervisord.conf
@@ -83,18 +82,10 @@ container_commands:
       supervisorctl -c /opt/python/etc/supervisord.conf update
     leader_only: true
 
-  02_kill_previous_celery_processes:
-    command: "ps auxww | grep 'celery' | awk '{print $2}' | sudo xargs kill -9 || true"
-    ignoreErrors: true
-
-  03_clear_pid_files:
-    command: "rm -f /tmp/*.pid"
-    leader_only: true
-
-  04_restart_celery_beat:
+  02_restart_celery_beat:
     command: "supervisorctl -c /opt/python/etc/supervisord.conf restart celerybeat"
     leader_only: true
 
-  05_restart_celery_worker:
+  03_restart_celery_worker:
     command: "supervisorctl -c /opt/python/etc/supervisord.conf restart celeryworker"
     leader_only: true

--- a/.ebextensions/03_celery.config
+++ b/.ebextensions/03_celery.config
@@ -106,8 +106,7 @@ files:
       # Update supervisord in cache without restarting all services
       supervisorctl -c /opt/python/etc/supervisord.conf update
 
-      # Restart celerybeat
-      supervisorctl -c /opt/python/etc/supervisord.conf restart celerybeat
-
-      # Restart celeryworker
-      supervisorctl -c /opt/python/etc/supervisord.conf restart celeryworker
+      # Restart celery processes
+      rm -f /tmp/*.pid
+      supervisorctl -c /opt/python/etc/supervisord.conf restart celerybeat || true
+      supervisorctl -c /opt/python/etc/supervisord.conf restart celeryworker || true

--- a/.ebextensions/03_celery.config
+++ b/.ebextensions/03_celery.config
@@ -81,11 +81,20 @@ files:
       # Update supervisord in cache without restarting all services
       supervisorctl -c /opt/python/etc/supervisord.conf update
 
-      # Restart celerybeat
-      supervisorctl -c /opt/python/etc/supervisord.conf restart celerybeat
+      # Stop celery processes
+      supervisorctl -c /opt/python/etc/supervisord.conf stop celerybeat
+      supervisorctl -c /opt/python/etc/supervisord.conf stop celeryworker
+      ps auxww | grep 'celery' | awk '{print $2}' | sudo xargs kill -9 || true
 
-      # Restart celeryworker
-      supervisorctl -c /opt/python/etc/supervisord.conf restart celeryworker
+      # Remove pid files
+      rm /tmp/*.pid
+
+      # Start celerybeat
+      supervisorctl -c /opt/python/etc/supervisord.conf start celerybeat
+
+      # Start celeryworker
+      supervisorctl -c /opt/python/etc/supervisord.conf start celeryworker
+
 
   "/opt/elasticbeanstalk/hooks/configdeploy/post/99_celery.sh":
     mode: "000755"

--- a/.ebextensions/03_celery.config
+++ b/.ebextensions/03_celery.config
@@ -86,3 +86,29 @@ files:
 
       # Restart celeryworker
       supervisorctl -c /opt/python/etc/supervisord.conf restart celeryworker
+
+  "/opt/elasticbeanstalk/hooks/configdeploy/post/99_celery.sh":
+    mode: "000755"
+    owner: root
+    group: root
+    content: |
+      touch /opt/python/log/celerybeat.log
+      touch /opt/python/log/celeryworker.log
+
+      if ! grep -Fxq "[include]" /opt/python/etc/supervisord.conf; then
+          echo "" | tee -a /opt/python/etc/supervisord.conf
+          echo "[include]" | tee -a /opt/python/etc/supervisord.conf
+          echo "files: celery.conf" | tee -a /opt/python/etc/supervisord.conf
+      fi
+
+      # Reread the supervisord config
+      supervisorctl -c /opt/python/etc/supervisord.conf reread
+
+      # Update supervisord in cache without restarting all services
+      supervisorctl -c /opt/python/etc/supervisord.conf update
+
+      # Restart celerybeat
+      supervisorctl -c /opt/python/etc/supervisord.conf restart celerybeat
+
+      # Restart celeryworker
+      supervisorctl -c /opt/python/etc/supervisord.conf restart celeryworker

--- a/.ebextensions/03_celery.config
+++ b/.ebextensions/03_celery.config
@@ -81,20 +81,10 @@ files:
       # Update supervisord in cache without restarting all services
       supervisorctl -c /opt/python/etc/supervisord.conf update
 
-      # Stop celery processes
-      supervisorctl -c /opt/python/etc/supervisord.conf stop celerybeat || true
-      supervisorctl -c /opt/python/etc/supervisord.conf stop celeryworker || true
-      ps auxww | grep 'celery' | awk '{print $2}' | sudo xargs kill -9 || true
-
-      # Remove pid files
-      rm /tmp/*.pid
-
-      # Start celerybeat
-      supervisorctl -c /opt/python/etc/supervisord.conf start celerybeat
-
-      # Start celeryworker
-      supervisorctl -c /opt/python/etc/supervisord.conf start celeryworker
-
+      # Restart celery processes
+      rm -f /tmp/*.pid
+      supervisorctl -c /opt/python/etc/supervisord.conf restart celerybeat || true
+      supervisorctl -c /opt/python/etc/supervisord.conf restart celeryworker || true
 
   "/opt/elasticbeanstalk/hooks/configdeploy/post/99_celery.sh":
     mode: "000755"

--- a/.ebextensions/03_celery.config
+++ b/.ebextensions/03_celery.config
@@ -25,7 +25,7 @@ files:
 
       [program:celerybeat]
       ; Load environmental variables and start beat
-      command=/bin/bash -c "source /opt/python/current/env && /opt/python/run/venv/bin/celery beat -A app"
+      command=/bin/bash -c "source /opt/python/current/env && /opt/python/run/venv/bin/celery beat -A app --pidfile=/tmp/celerybeat.pid"
 
       ; Full path to Django app
       directory=/opt/python/current/app
@@ -46,7 +46,7 @@ files:
 
       [program:celeryworker]
       ; Load environmental variables and start worker
-      command=/bin/bash -c "source /opt/python/current/env && /opt/python/run/venv/bin/celery -A app worker -l info"
+      command=/bin/bash -c "source /opt/python/current/env && /opt/python/run/venv/bin/celery -A app worker -l info --pidfile=/tmp/celeryworker.pid"
 
       ; Full path to Django app
       directory=/opt/python/current/app

--- a/.ebextensions/03_celery.config
+++ b/.ebextensions/03_celery.config
@@ -61,14 +61,14 @@ files:
       ; Set its priority higher so it starts first
       priority=999
 
-container_commands:
-  00_touch_celery_logs:
-    command: |
+  "/opt/elasticbeanstalk/hooks/appdeploy/post/99_celery.sh":
+    mode: "000755"
+    owner: root
+    group: root
+    content: |
       touch /opt/python/log/celerybeat.log
       touch /opt/python/log/celeryworker.log
 
-  01_add_celery_to_supervisord:
-    command: |
       if ! grep -Fxq "[include]" /opt/python/etc/supervisord.conf; then
           echo "" | tee -a /opt/python/etc/supervisord.conf
           echo "[include]" | tee -a /opt/python/etc/supervisord.conf
@@ -80,12 +80,9 @@ container_commands:
 
       # Update supervisord in cache without restarting all services
       supervisorctl -c /opt/python/etc/supervisord.conf update
-    leader_only: true
 
-  02_restart_celery_beat:
-    command: "supervisorctl -c /opt/python/etc/supervisord.conf restart celerybeat"
-    leader_only: true
+      # Restart celerybeat
+      supervisorctl -c /opt/python/etc/supervisord.conf restart celerybeat
 
-  03_restart_celery_worker:
-    command: "supervisorctl -c /opt/python/etc/supervisord.conf restart celeryworker"
-    leader_only: true
+      # Restart celeryworker
+      supervisorctl -c /opt/python/etc/supervisord.conf restart celeryworker


### PR DESCRIPTION
- Moved from executing container commands to post deploy bash scripts. The reason for this is that container commands are executed in staging environment while existing application is still deployed. There were clashes on multiple processes running concurrently. By running after deploy, we can simply remove the PID files and restart the two programs instead of manually killing the programs' processes. 
- Also added `|| true` to the restart commands. In bash scripting `|| true` means ignore any errors from the script. We do this because if the programs are already stopped, then running `restart [program_name]` will raise an error that the program is not running.