### PR TITLE
API-142: Set up Django feature flipping

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -48,6 +48,7 @@ INSTALLED_APPS = [
     'django_fsm',
     'fsm_admin',
     'corsheaders',
+    'waffle',
     'storages',
     'app.users',
     'app.groups',
@@ -59,6 +60,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     'corsheaders.middleware.CorsMiddleware',
+    'waffle.middleware.WaffleMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -158,3 +160,6 @@ if os.environ.get('RAVEN_DSN'):
         'dsn': os.environ['RAVEN_DSN'],
         'release': VERSION
     }
+
+# http://waffle.readthedocs.io/en/latest/starting/configuring.html
+WAFFLE_SWITCH_DEFAULT = False

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ django-fsm==2.6.0
 django-fsm-admin==1.2.4
 django-model-utils==3.1.1
 django-storages==1.6.5
+django-waffle==0.13.0
 djangorestframework==3.7.7
 docutils==0.14
 ephem==3.7.6.0


### PR DESCRIPTION
- Decided to use django-waffle for feature flipping. It seems to be one of the most popular (along with Gargoyle although it doesn't yet officially support py3). Comes recommended from Kenneth Love.
