### PR TITLE
API-136: Remove slack domain from post to slack app

### DIFF
--- a/app/api/wrappers.py
+++ b/app/api/wrappers.py
@@ -7,22 +7,22 @@ from django.core.exceptions import ObjectDoesNotExist
 
 class SlackAppClientWrapper:
     @staticmethod
-    def construct_headers():
+    def __construct_headers():
         headers = {'Authorization': f'Token {settings.SLACK_APP_VERIFICATION_TOKEN}',
                    'Content-Type': 'application/json'}
         return headers
 
     @staticmethod
-    def construct_slack_discussion_payload(discussion):
+    def __construct_slack_discussion_payload(discussion):
         return {'slack_channel_id': discussion.slack_channel.id,
                 'slack_team_id': discussion.slack_channel.slack_team.id}
 
     @staticmethod
-    def construct_discussion_payload(discussion):
+    def __construct_discussion_payload(discussion):
         return {'discussion_id': discussion.id}
 
     @staticmethod
-    def construct_slack_agent_payload(slack_agent):
+    def __construct_slack_agent_payload(slack_agent):
         slack_agent_payload = {'status': slack_agent.status,
                                'topic_channel_id': slack_agent.topic_channel_id,
                                'slack_application_installation': {},
@@ -60,39 +60,37 @@ class SlackAppClientWrapper:
 
         return slack_agent_payload
 
-    @staticmethod
-    def post_discussion(endpoint, discussion):
-        headers = SlackAppClientWrapper.construct_headers()
+    @classmethod
+    def __post_discussion(cls, endpoint, discussion):
+        headers = cls.__construct_headers()
         if waffle.switch_is_active('use_slack_domain'):
-            payload = SlackAppClientWrapper.construct_slack_discussion_payload(discussion)
+            payload = cls.__construct_slack_discussion_payload(discussion)
         else:
-            payload = SlackAppClientWrapper.construct_discussion_payload(discussion)
+            payload = cls.__construct_discussion_payload(discussion)
 
         resp = requests.post(endpoint, json=payload, headers=headers)
         assert 200 <= resp.status_code < 300, resp.content
 
-    @staticmethod
-    def post_auto_closed_discussion(discussion):
-        SlackAppClientWrapper.post_discussion(settings.SLACK_APP_AUTO_CLOSED_DISCUSSION_ENDPOINT,
-                                               discussion)
+    @classmethod
+    def post_auto_closed_discussion(cls, discussion):
+        cls.__post_discussion(settings.SLACK_APP_AUTO_CLOSED_DISCUSSION_ENDPOINT, discussion)
 
-    @staticmethod
-    def post_stale_discussion(discussion):
-        SlackAppClientWrapper.__post_discussion(settings.SLACK_APP_STALE_DISCUSSION_ENDPOINT,
-                                                discussion)
+    @classmethod
+    def post_stale_discussion(cls, discussion):
+        cls.__post_discussion(settings.SLACK_APP_STALE_DISCUSSION_ENDPOINT, discussion)
 
-    @staticmethod
-    def post_slack_agent(slack_agent):
-        headers = SlackAppClientWrapper.construct_headers()
-        payload = SlackAppClientWrapper.construct_slack_agent_payload(slack_agent)
+    @classmethod
+    def post_slack_agent(cls, slack_agent):
+        headers = cls.__construct_headers()
+        payload = cls.__construct_slack_agent_payload(slack_agent)
 
         resp = requests.post(settings.SLACK_APP_SLACK_AGENT_ENDPOINT, json=payload, headers=headers)
         assert 200 <= resp.status_code < 300, resp.content
 
-    @staticmethod
-    def put_slack_agent(slack_agent):
-        headers = SlackAppClientWrapper.construct_headers()
-        payload = SlackAppClientWrapper.construct_slack_agent_payload(slack_agent)
+    @classmethod
+    def put_slack_agent(cls, slack_agent):
+        headers = cls.__construct_headers()
+        payload = cls.__construct_slack_agent_payload(slack_agent)
 
         resp = requests.put(settings.SLACK_APP_SLACK_AGENT_ENDPOINT, json=payload, headers=headers)
         assert 200 <= resp.status_code < 300, resp.content

--- a/app/api/wrappers.py
+++ b/app/api/wrappers.py
@@ -7,22 +7,22 @@ from django.core.exceptions import ObjectDoesNotExist
 
 class SlackAppClientWrapper:
     @staticmethod
-    def _construct_headers():
+    def construct_headers():
         headers = {'Authorization': f'Token {settings.SLACK_APP_VERIFICATION_TOKEN}',
                    'Content-Type': 'application/json'}
         return headers
 
     @staticmethod
-    def _construct_slack_discussion_payload(discussion):
+    def construct_slack_discussion_payload(discussion):
         return {'slack_channel_id': discussion.slack_channel.id,
                 'slack_team_id': discussion.slack_channel.slack_team.id}
 
     @staticmethod
-    def _construct_discussion_payload(discussion):
+    def construct_discussion_payload(discussion):
         return {'discussion_id': discussion.id}
 
     @staticmethod
-    def _construct_slack_agent_payload(slack_agent):
+    def construct_slack_agent_payload(slack_agent):
         slack_agent_payload = {'status': slack_agent.status,
                                'topic_channel_id': slack_agent.topic_channel_id,
                                'slack_application_installation': {},
@@ -61,38 +61,38 @@ class SlackAppClientWrapper:
         return slack_agent_payload
 
     @staticmethod
-    def _post_discussion(endpoint, discussion):
-        headers = SlackAppClientWrapper._construct_headers()
+    def post_discussion(endpoint, discussion):
+        headers = SlackAppClientWrapper.construct_headers()
         if waffle.switch_is_active('use_slack_domain'):
-            payload = SlackAppClientWrapper._construct_slack_discussion_payload(discussion)
+            payload = SlackAppClientWrapper.construct_slack_discussion_payload(discussion)
         else:
-            payload = SlackAppClientWrapper._construct_discussion_payload(discussion)
+            payload = SlackAppClientWrapper.construct_discussion_payload(discussion)
 
         resp = requests.post(endpoint, json=payload, headers=headers)
         assert 200 <= resp.status_code < 300, resp.content
 
     @staticmethod
     def post_auto_closed_discussion(discussion):
-        SlackAppClientWrapper._post_discussion(settings.SLACK_APP_AUTO_CLOSED_DISCUSSION_ENDPOINT,
+        SlackAppClientWrapper.post_discussion(settings.SLACK_APP_AUTO_CLOSED_DISCUSSION_ENDPOINT,
                                                discussion)
 
     @staticmethod
     def post_stale_discussion(discussion):
-        SlackAppClientWrapper._post_discussion(settings.SLACK_APP_STALE_DISCUSSION_ENDPOINT,
-                                               discussion)
+        SlackAppClientWrapper.__post_discussion(settings.SLACK_APP_STALE_DISCUSSION_ENDPOINT,
+                                                discussion)
 
     @staticmethod
     def post_slack_agent(slack_agent):
-        headers = SlackAppClientWrapper._construct_headers()
-        payload = SlackAppClientWrapper._construct_slack_agent_payload(slack_agent)
+        headers = SlackAppClientWrapper.construct_headers()
+        payload = SlackAppClientWrapper.construct_slack_agent_payload(slack_agent)
 
         resp = requests.post(settings.SLACK_APP_SLACK_AGENT_ENDPOINT, json=payload, headers=headers)
         assert 200 <= resp.status_code < 300, resp.content
 
     @staticmethod
     def put_slack_agent(slack_agent):
-        headers = SlackAppClientWrapper._construct_headers()
-        payload = SlackAppClientWrapper._construct_slack_agent_payload(slack_agent)
+        headers = SlackAppClientWrapper.construct_headers()
+        payload = SlackAppClientWrapper.construct_slack_agent_payload(slack_agent)
 
         resp = requests.put(settings.SLACK_APP_SLACK_AGENT_ENDPOINT, json=payload, headers=headers)
         assert 200 <= resp.status_code < 300, resp.content

--- a/app/slack_integration/models.py
+++ b/app/slack_integration/models.py
@@ -8,7 +8,7 @@ from model_utils.models import TimeStampedModel
 
 from app.dialogues.models import Message
 from app.groups.models import Group
-from app.slack_integration.wrappers import SlackAppClientWrapper
+from app.api.wrappers import SlackAppClientWrapper
 from app.topics.models import Discussion
 from app.users.models import User
 

--- a/app/topics/tasks.py
+++ b/app/topics/tasks.py
@@ -2,7 +2,7 @@ from django.conf import settings
 
 from app.api.celery import celery_app
 from app.topics.models import Discussion, DiscussionStatus
-from app.slack_integration.wrappers import SlackAppClientWrapper
+from app.api.wrappers import SlackAppClientWrapper
 
 
 @celery_app.task

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,9 +23,11 @@ from tests.factories import (
     TagFactory,
     UserFactory
 )
+from tests.resources.MutationGenerator import MutationGenerator
 from tests.resources.TestSlackClient import TestSlackClient
 from tests.resources.test_celery_tasks import run_auto_close_pending_closed_discussion_task,\
     run_mark_stale_discussions_task
+from tests.resources.QueryGenerator import QueryGenerator
 
 register(GroupFactory)
 register(MessageFactory)
@@ -149,3 +151,13 @@ def mark_stale_discussion_task(transactional_db):
 @pytest.fixture()
 def use_slack_domain():
     Switch.objects.create(name='use_slack_domain', active=True)
+
+
+@pytest.fixture()
+def mutation_generator():
+    yield MutationGenerator
+
+
+@pytest.fixture()
+def query_generator():
+    yield QueryGenerator

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,11 +23,9 @@ from tests.factories import (
     TagFactory,
     UserFactory
 )
-from tests.resources.MutationGenerator import MutationGenerator
 from tests.resources.TestSlackClient import TestSlackClient
 from tests.resources.test_celery_tasks import run_auto_close_pending_closed_discussion_task,\
     run_mark_stale_discussions_task
-from tests.resources.QueryGenerator import QueryGenerator
 
 register(GroupFactory)
 register(MessageFactory)
@@ -151,13 +149,3 @@ def mark_stale_discussion_task(transactional_db):
 @pytest.fixture()
 def use_slack_domain():
     Switch.objects.create(name='use_slack_domain', active=True)
-
-
-@pytest.fixture()
-def mutation_generator():
-    yield MutationGenerator
-
-
-@pytest.fixture()
-def query_generator():
-    yield QueryGenerator

--- a/tests/func/api/test_authentication_api.py
+++ b/tests/func/api/test_authentication_api.py
@@ -10,7 +10,7 @@ class TestAPIAuthentication:
         data = {'email': user.email, 'password': 'mypass123!'}
         response = client.post('/auth-token', data)
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['token']
 
     @pytest.mark.django_db

--- a/tests/func/dialogues/test_create_message.py
+++ b/tests/func/dialogues/test_create_message.py
@@ -3,51 +3,53 @@ from datetime import datetime, timedelta
 
 import pytest
 
+from tests.resources.MutationGenerator import MutationGenerator
+
 
 class TestCreateMessage:
 
     @pytest.mark.django_db
-    def test_unauthenticated(self, client, mutation_generator, discussion_factory, user_factory, message_factory):
+    def test_unauthenticated(self, client, discussion_factory, user_factory, message_factory):
         discussion = discussion_factory(topic__is_private=False)
         user = user_factory()
         message = message_factory.build(discussion=discussion, author=user)
 
-        mutation = mutation_generator.create_message(message.text, discussion.id, user.id, message.time)
+        mutation = MutationGenerator.create_message(message.text, discussion.id, user.id, message.time)
         response = client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createMessage'] is None
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_closed_discussion(self, auth_client, mutation_generator, discussion_factory,
+    def test_closed_discussion(self, auth_client, discussion_factory,
                                user_factory, message_factory):
         discussion = discussion_factory(topic__is_private=False, status='CLOSED')
         user = user_factory()
         message = message_factory.build(discussion=discussion, author=user)
 
-        mutation = mutation_generator.create_message(message.text, discussion.id, user.id, message.time)
+        mutation = MutationGenerator.create_message(message.text, discussion.id, user.id, message.time)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createMessage'] is None
         assert response.json()['errors'][0]['message'] == "{'non_field_errors': ['Cannot create message in closed " \
                                                           "discussion']}"
 
     @pytest.mark.django_db
-    def test_valid(self, auth_client, mutation_generator, discussion_factory, user_factory, message_factory):
+    def test_valid(self, auth_client, discussion_factory, user_factory, message_factory):
         discussion = discussion_factory(topic__is_private=False)
         user = user_factory()
         message = message_factory.build(discussion=discussion, author=user)
 
-        mutation = mutation_generator.create_message(message.text, discussion.id, user.id, message.time)
+        mutation = MutationGenerator.create_message(message.text, discussion.id, user.id, message.time)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createMessage']['message']['text'] == message.text
 
     @pytest.mark.django_db()
-    def test_marks_discussion_as_open(self, auth_client, mutation_generator, discussion_factory,
+    def test_marks_discussion_as_open(self, auth_client, discussion_factory,
                                       user_factory, message_factory):
         discussion = discussion_factory(topic__is_private=False)
         user = user_factory(is_bot=False)
@@ -57,9 +59,9 @@ class TestCreateMessage:
 
         message = message_factory.build(discussion=discussion, author=user)
 
-        mutation = mutation_generator.create_message(message.text, discussion.id, user.id, message.time)
+        mutation = MutationGenerator.create_message(message.text, discussion.id, user.id, message.time)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createMessage']['message']['text'] == message.text
         assert response.json()['data']['createMessage']['message']['discussion']['status'] == 'OPEN'

--- a/tests/func/dialogues/test_create_reply.py
+++ b/tests/func/dialogues/test_create_reply.py
@@ -3,47 +3,48 @@ from datetime import datetime, timedelta
 
 import pytest
 
+from tests.resources.MutationGenerator import MutationGenerator
+
 
 class TestCreateReply:
 
     @pytest.mark.django_db
-    def test_unauthenticated(self, client, mutation_generator, message_factory, reply_factory):
+    def test_unauthenticated(self, client, message_factory, reply_factory):
         message = message_factory()
         reply = reply_factory.build(message=message)
 
-        mutation = mutation_generator.create_reply(reply.text, reply.message.id, message.author.id, reply.time)
+        mutation = MutationGenerator.create_reply(reply.text, reply.message.id, message.author.id, reply.time)
         response = client.post('/graphql', {'query': mutation})
 
         assert response.json()['data']['createReply'] is None
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_closed_discussion(self, auth_client, mutation_generator, discussion_factory, message_factory,
-                               reply_factory):
+    def test_closed_discussion(self, auth_client, discussion_factory, message_factory, reply_factory):
         discussion = discussion_factory(status='CLOSED')
         message = message_factory(discussion=discussion)
         reply = reply_factory.build(message=message)
 
-        mutation = mutation_generator.create_reply(reply.text, reply.message.id, message.author.id, reply.time)
+        mutation = MutationGenerator.create_reply(reply.text, reply.message.id, message.author.id, reply.time)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createReply'] is None
         assert response.json()['errors'][0]['message'] == "{'non_field_errors': ['Cannot create reply to message in " \
                                                           "closed discussion']}"
 
     @pytest.mark.django_db
-    def test_valid(self, auth_client, mutation_generator, message_factory, reply_factory):
+    def test_valid(self, auth_client, message_factory, reply_factory):
         message = message_factory(discussion__topic__is_private=False)
         reply = reply_factory.build(message=message)
 
-        mutation = mutation_generator.create_reply(reply.text, reply.message.id, message.author.id, reply.time)
+        mutation = MutationGenerator.create_reply(reply.text, reply.message.id, message.author.id, reply.time)
         response = auth_client.post('/graphql', {'query': mutation})
 
         assert response.json()['data']['createReply']['reply']['text'] == reply.text
 
     @pytest.mark.django_db()
-    def test_marks_discussion_as_open(self, auth_client, mutation_generator, discussion_factory, user_factory,
+    def test_marks_discussion_as_open(self, auth_client, discussion_factory, user_factory,
                                       message_factory, reply_factory):
         message_author = user_factory(is_bot=False)
         reply_author = user_factory(is_bot=False)
@@ -54,9 +55,9 @@ class TestCreateReply:
         discussion.save()
         reply = reply_factory.build(message=message, author=reply_author)
 
-        mutation = mutation_generator.create_reply(reply.text, reply.message.id, message.author.id, reply.time)
+        mutation = MutationGenerator.create_reply(reply.text, reply.message.id, message.author.id, reply.time)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createReply']['reply']['text'] == reply.text
         assert response.json()['data']['createReply']['reply']['message']['discussion']['status'] == 'OPEN'

--- a/tests/func/dialogues/test_create_reply.py
+++ b/tests/func/dialogues/test_create_reply.py
@@ -7,41 +7,24 @@ import pytest
 class TestCreateReply:
 
     @pytest.mark.django_db
-    def test_unauthenticated(self, client, message_factory, reply_factory):
+    def test_unauthenticated(self, client, mutation_generator, message_factory, reply_factory):
         message = message_factory()
         reply = reply_factory.build(message=message)
 
-        mutation = f'''
-          mutation {{
-            createReply(input: {{text: "{reply.text}", messageId: {message.id}, authorId: {message.author.id},
-                                 time: "{reply.time}"}}) {{
-              reply {{
-                text
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_reply(reply.text, reply.message.id, message.author.id, reply.time)
         response = client.post('/graphql', {'query': mutation})
 
         assert response.json()['data']['createReply'] is None
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_closed_discussion(self, auth_client, discussion_factory, message_factory, reply_factory):
+    def test_closed_discussion(self, auth_client, mutation_generator, discussion_factory, message_factory,
+                               reply_factory):
         discussion = discussion_factory(status='CLOSED')
         message = message_factory(discussion=discussion)
         reply = reply_factory.build(message=message)
 
-        mutation = f'''
-          mutation {{
-            createReply(input: {{text: "{reply.text}", messageId: {message.id}, authorId: {message.author.id},
-                                 time: "{reply.time}"}}) {{
-              reply {{
-                text
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_reply(reply.text, reply.message.id, message.author.id, reply.time)
         response = auth_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200
@@ -50,27 +33,18 @@ class TestCreateReply:
                                                           "closed discussion']}"
 
     @pytest.mark.django_db
-    def test_valid(self, auth_client, message_factory, reply_factory):
+    def test_valid(self, auth_client, mutation_generator, message_factory, reply_factory):
         message = message_factory(discussion__topic__is_private=False)
         reply = reply_factory.build(message=message)
 
-        mutation = f'''
-          mutation {{
-            createReply(input: {{text: "{reply.text}", messageId: {message.id}, authorId: {message.author.id},
-                                 time: "{reply.time}"}}) {{
-              reply {{
-                text
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_reply(reply.text, reply.message.id, message.author.id, reply.time)
         response = auth_client.post('/graphql', {'query': mutation})
 
         assert response.json()['data']['createReply']['reply']['text'] == reply.text
 
     @pytest.mark.django_db()
-    def test_marks_discussion_as_open(self, auth_client, discussion_factory, user_factory, message_factory,
-                                      reply_factory):
+    def test_marks_discussion_as_open(self, auth_client, mutation_generator, discussion_factory, user_factory,
+                                      message_factory, reply_factory):
         message_author = user_factory(is_bot=False)
         reply_author = user_factory(is_bot=False)
         discussion = discussion_factory(topic__is_private=False)
@@ -78,24 +52,9 @@ class TestCreateReply:
                                   author=message_author)
         discussion.mark_as_stale()
         discussion.save()
-
         reply = reply_factory.build(message=message, author=reply_author)
 
-        mutation = f'''
-          mutation {{
-            createReply(input: {{text: "{reply.text}", messageId: {reply.message.id}, authorId: {message.author.id},
-                                 time: "{reply.time}"}}) {{
-              reply {{
-                text
-                message {{
-                  discussion {{
-                    status
-                  }}
-                }}
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_reply(reply.text, reply.message.id, message.author.id, reply.time)
         response = auth_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200

--- a/tests/func/dialogues/test_query_messages.py
+++ b/tests/func/dialogues/test_query_messages.py
@@ -1,44 +1,46 @@
 import pytest
 
+from tests.resources.QueryGenerator import QueryGenerator
+
 
 class TestQueryMessages:
 
     @pytest.mark.django_db
-    def test_get_message(self, client, query_generator, message_factory):
+    def test_get_message(self, client, message_factory):
         message = message_factory(discussion__topic__is_private=False)
 
-        response = client.post('/graphql', {'query': query_generator.get_message(message.id)})
+        response = client.post('/graphql', {'query': QueryGenerator.get_message(message.id)})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['message']['text'] == message.text
 
     @pytest.mark.django_db
-    def test_get_message_private_discussion_topic(self, client, query_generator, message_factory):
+    def test_get_message_private_discussion_topic(self, client, message_factory):
         message = message_factory(discussion__topic__is_private=True)
 
-        response = client.post('/graphql', {'query': query_generator.get_message(message.id)})
+        response = client.post('/graphql', {'query': QueryGenerator.get_message(message.id)})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['message'] is None
 
     @pytest.mark.django_db
-    def test_get_messages(self, client, query_generator, message_factory):
+    def test_get_messages(self, client, message_factory):
         message_factory(discussion__topic__is_private=False)
         message_factory(discussion__topic__is_private=False)
 
-        response = client.post('/graphql', {'query': query_generator.get_messages()})
+        response = client.post('/graphql', {'query': QueryGenerator.get_messages()})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert len(response.json()['data']['messages']) == 2
         assert response.json()['data']['messages'][0]['text']
 
     @pytest.mark.django_db
-    def test_get_messages_private_discussion_topic(self, client, query_generator, message_factory):
+    def test_get_messages_private_discussion_topic(self, client, message_factory):
         message_factory(discussion__topic__is_private=True)
         message_factory(discussion__topic__is_private=True)
 
-        response = client.post('/graphql', {'query': query_generator.get_messages()})
+        response = client.post('/graphql', {'query': QueryGenerator.get_messages()})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert len(response.json()['data']['messages']) == 2
         assert response.json()['data']['messages'][0] is None

--- a/tests/func/dialogues/test_query_messages.py
+++ b/tests/func/dialogues/test_query_messages.py
@@ -4,44 +4,40 @@ import pytest
 class TestQueryMessages:
 
     @pytest.mark.django_db
-    def test_get_message(self, message_factory, client):
+    def test_get_message(self, client, query_generator, message_factory):
         message = message_factory(discussion__topic__is_private=False)
 
-        query = {'query': f'{{ message(id: {message.id}) {{ text }} }}'}
-        response = client.post('/graphql', query)
+        response = client.post('/graphql', {'query': query_generator.get_message(message.id)})
 
         assert response.status_code == 200
         assert response.json()['data']['message']['text'] == message.text
 
     @pytest.mark.django_db
-    def test_get_message_private_discussion_topic(self, message_factory, client):
+    def test_get_message_private_discussion_topic(self, client, query_generator, message_factory):
         message = message_factory(discussion__topic__is_private=True)
 
-        query = {'query': f'{{ message(id: {message.id}) {{ text }} }}'}
-        response = client.post('/graphql', query)
+        response = client.post('/graphql', {'query': query_generator.get_message(message.id)})
 
         assert response.status_code == 200
         assert response.json()['data']['message'] is None
 
     @pytest.mark.django_db
-    def test_get_messages(self, message_factory, client):
+    def test_get_messages(self, client, query_generator, message_factory):
         message_factory(discussion__topic__is_private=False)
         message_factory(discussion__topic__is_private=False)
 
-        query = {'query': '{ messages { text } }'}
-        response = client.post('/graphql', query)
+        response = client.post('/graphql', {'query': query_generator.get_messages()})
 
         assert response.status_code == 200
         assert len(response.json()['data']['messages']) == 2
         assert response.json()['data']['messages'][0]['text']
 
     @pytest.mark.django_db
-    def test_get_messages_private_discussion_topic(self, message_factory, client):
+    def test_get_messages_private_discussion_topic(self, client, query_generator, message_factory):
         message_factory(discussion__topic__is_private=True)
         message_factory(discussion__topic__is_private=True)
 
-        query = {'query': '{ messages { text } }'}
-        response = client.post('/graphql', query)
+        response = client.post('/graphql', {'query': query_generator.get_messages()})
 
         assert response.status_code == 200
         assert len(response.json()['data']['messages']) == 2

--- a/tests/func/dialogues/test_query_replies.py
+++ b/tests/func/dialogues/test_query_replies.py
@@ -1,44 +1,46 @@
 import pytest
 
+from tests.resources.QueryGenerator import QueryGenerator
+
 
 class TestQueryReplies:
 
     @pytest.mark.django_db
-    def test_get_reply(self, client, query_generator, reply_factory):
+    def test_get_reply(self, client, reply_factory):
         reply = reply_factory(message__discussion__topic__is_private=False)
 
-        response = client.post('/graphql', {'query': query_generator.get_reply(reply.id)})
+        response = client.post('/graphql', {'query': QueryGenerator.get_reply(reply.id)})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['reply']['message']['text']
 
     @pytest.mark.django_db
-    def test_get_reply_private_discussion_topic(self, client, query_generator, reply_factory):
+    def test_get_reply_private_discussion_topic(self, client, reply_factory):
         reply = reply_factory(message__discussion__topic__is_private=True)
 
-        response = client.post('/graphql', {'query': query_generator.get_reply(reply.id)})
+        response = client.post('/graphql', {'query': QueryGenerator.get_reply(reply.id)})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['reply'] is None
 
     @pytest.mark.django_db
-    def test_get_replies(self, client, query_generator, reply_factory):
+    def test_get_replies(self, client, reply_factory):
         reply_factory(message__discussion__topic__is_private=False)
         reply_factory(message__discussion__topic__is_private=False)
 
-        response = client.post('/graphql', {'query': query_generator.get_replies()})
+        response = client.post('/graphql', {'query': QueryGenerator.get_replies()})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert len(response.json()['data']['replies']) == 2
         assert response.json()['data']['replies'][0]['text']
 
     @pytest.mark.django_db
-    def test_get_replies_private_discussion_topic(self, client, query_generator, reply_factory):
+    def test_get_replies_private_discussion_topic(self, client, reply_factory):
         reply_factory(message__discussion__topic__is_private=True)
         reply_factory(message__discussion__topic__is_private=True)
 
-        response = client.post('/graphql', {'query': query_generator.get_replies()})
+        response = client.post('/graphql', {'query': QueryGenerator.get_replies()})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert len(response.json()['data']['replies']) == 2
         assert response.json()['data']['replies'][0] is None

--- a/tests/func/dialogues/test_query_replies.py
+++ b/tests/func/dialogues/test_query_replies.py
@@ -4,44 +4,40 @@ import pytest
 class TestQueryReplies:
 
     @pytest.mark.django_db
-    def test_get_reply(self, reply_factory, client):
+    def test_get_reply(self, client, query_generator, reply_factory):
         reply = reply_factory(message__discussion__topic__is_private=False)
 
-        query = {'query': f'{{ reply(id: {reply.id}) {{ message {{ text }} }} }}'}
-        response = client.post('/graphql', query)
+        response = client.post('/graphql', {'query': query_generator.get_reply(reply.id)})
 
         assert response.status_code == 200
         assert response.json()['data']['reply']['message']['text']
 
     @pytest.mark.django_db
-    def test_get_reply_private_discussion_topic(self, reply_factory, client):
+    def test_get_reply_private_discussion_topic(self, client, query_generator, reply_factory):
         reply = reply_factory(message__discussion__topic__is_private=True)
 
-        query = {'query': f'{{ reply(id: {reply.id}) {{ message {{ text }} }} }}'}
-        response = client.post('/graphql', query)
+        response = client.post('/graphql', {'query': query_generator.get_reply(reply.id)})
 
         assert response.status_code == 200
         assert response.json()['data']['reply'] is None
 
     @pytest.mark.django_db
-    def test_get_replies(self, reply_factory, client):
+    def test_get_replies(self, client, query_generator, reply_factory):
         reply_factory(message__discussion__topic__is_private=False)
         reply_factory(message__discussion__topic__is_private=False)
 
-        query = {'query': '{ replies { text } }'}
-        response = client.post('/graphql', query)
+        response = client.post('/graphql', {'query': query_generator.get_replies()})
 
         assert response.status_code == 200
         assert len(response.json()['data']['replies']) == 2
         assert response.json()['data']['replies'][0]['text']
 
     @pytest.mark.django_db
-    def test_get_replies_private_discussion_topic(self, reply_factory, client):
+    def test_get_replies_private_discussion_topic(self, client, query_generator, reply_factory):
         reply_factory(message__discussion__topic__is_private=True)
         reply_factory(message__discussion__topic__is_private=True)
 
-        query = {'query': '{ replies { text } }'}
-        response = client.post('/graphql', query)
+        response = client.post('/graphql', {'query': query_generator.get_replies()})
 
         assert response.status_code == 200
         assert len(response.json()['data']['replies']) == 2

--- a/tests/func/groups/test_create_group.py
+++ b/tests/func/groups/test_create_group.py
@@ -1,25 +1,27 @@
 import pytest
 
+from tests.resources.MutationGenerator import MutationGenerator
+
 
 class TestCreateGroup:
 
     @pytest.mark.django_db
-    def test_unauthenticated(self, client, mutation_generator, group_factory):
+    def test_unauthenticated(self, client, group_factory):
         group = group_factory.build()
 
-        mutation = mutation_generator.create_group(group.name)
+        mutation = MutationGenerator.create_group(group.name)
         response = client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createGroup'] is None
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_valid(self, auth_client, mutation_generator, group_factory):
+    def test_valid(self, auth_client, group_factory):
         group = group_factory.build()
 
-        mutation = mutation_generator.create_group(group.name)
+        mutation = MutationGenerator.create_group(group.name)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createGroup']['group']['name'] == group.name

--- a/tests/func/groups/test_create_group.py
+++ b/tests/func/groups/test_create_group.py
@@ -4,18 +4,10 @@ import pytest
 class TestCreateGroup:
 
     @pytest.mark.django_db
-    def test_unauthenticated(self, client, group_factory):
+    def test_unauthenticated(self, client, mutation_generator, group_factory):
         group = group_factory.build()
 
-        mutation = f'''
-          mutation {{
-            createGroup(input: {{name: "{group.name}"}}) {{
-              group {{
-                name
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_group(group.name)
         response = client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200
@@ -23,18 +15,10 @@ class TestCreateGroup:
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_valid(self, auth_client, group_factory):
+    def test_valid(self, auth_client, mutation_generator, group_factory):
         group = group_factory.build()
 
-        mutation = f'''
-          mutation {{
-            createGroup(input: {{name: "{group.name}"}}) {{
-              group {{
-                name
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_group(group.name)
         response = auth_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200

--- a/tests/func/groups/test_query_groups.py
+++ b/tests/func/groups/test_query_groups.py
@@ -1,5 +1,7 @@
 import pytest
 
+from tests.resources.QueryGenerator import QueryGenerator
+
 
 class TestQueryGroups:
 
@@ -7,10 +9,10 @@ class TestQueryGroups:
     def test_get_group(self, group_factory, client):
         group = group_factory()
 
-        query = {'query': f'{{ group(name: "{group.name}") {{ id }} }}'}
-        response = client.post('/graphql', query)
+        query = QueryGenerator.get_group(group.name)
+        response = client.post('/graphql', {'query': query})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['group']['id'] == str(group.id)
 
     @pytest.mark.django_db
@@ -18,8 +20,8 @@ class TestQueryGroups:
         group_factory()
         group_factory()
 
-        query = {'query': '{ groups { name } }'}
-        response = client.post('/graphql', query)
+        query = QueryGenerator.get_groups()
+        response = client.post('/graphql', {'query': query})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert len(response.json()['data']['groups']) == 2

--- a/tests/func/slack_integration/test_attempt_slack_installation.py
+++ b/tests/func/slack_integration/test_attempt_slack_installation.py
@@ -1,32 +1,34 @@
 import pytest
 
+from tests.resources.MutationGenerator import MutationGenerator
+
 
 class TestAttemptSlackInstallation:
 
     @pytest.mark.django_db
     @pytest.mark.parametrize('slack_oauth_request', ['invalid_token'], indirect=True)
     @pytest.mark.usefixtures('slack_oauth_request')
-    def test_invalid_token(self, client, mutation_generator):
+    def test_invalid_token(self, client):
         code = '123456789012.123456789012.1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGHIJKLMNOPQR'
         client_id = '123456789012.123456789012.123456'
         redirect_uri = 'www.app.trystrand.com/install'
 
-        mutation = mutation_generator.attempt_slack_installation(code, client_id, redirect_uri)
+        mutation = MutationGenerator.attempt_slack_installation(code, client_id, redirect_uri)
         response = client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['errors'][0]['message'] == 'Error accessing OAuth: invalid_code'
 
     @pytest.mark.django_db
     @pytest.mark.parametrize('slack_oauth_request', ['valid_token'], indirect=True)
     @pytest.mark.usefixtures('slack_client', 'slack_oauth_request')
-    def test_valid(self, client, mutation_generator):
+    def test_valid(self, client):
         code = '123456789012.123456789012.1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGHIJKLMNOPQR'
         client_id = '123456789012.123456789012.123456'
         redirect_uri = 'www.app.trystrand.com/install'
 
-        mutation = mutation_generator.attempt_slack_installation(code, client_id, redirect_uri)
+        mutation = MutationGenerator.attempt_slack_installation(code, client_id, redirect_uri)
         response = client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['attemptSlackInstallation']['slackTeam']['name'] == 'Clippy Sandbox'

--- a/tests/func/slack_integration/test_attempt_slack_installation.py
+++ b/tests/func/slack_integration/test_attempt_slack_installation.py
@@ -6,41 +6,27 @@ class TestAttemptSlackInstallation:
     @pytest.mark.django_db
     @pytest.mark.parametrize('slack_oauth_request', ['invalid_token'], indirect=True)
     @pytest.mark.usefixtures('slack_oauth_request')
-    def test_invalid_token(self, client):
+    def test_invalid_token(self, client, mutation_generator):
         code = '123456789012.123456789012.1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGHIJKLMNOPQR'
         client_id = '123456789012.123456789012.123456'
         redirect_uri = 'www.app.trystrand.com/install'
-        mutation = f'''
-          mutation {{
-            attemptSlackInstallation(input: {{code: "{code}",
-                                              clientId: "{client_id}", redirectUri: "{redirect_uri}"}}) {{
-              slackTeam {{
-                name
-              }}
-            }}
-          }}
-        '''
+
+        mutation = mutation_generator.attempt_slack_installation(code, client_id, redirect_uri)
         response = client.post('/graphql', {'query': mutation})
+
         assert response.status_code == 200
         assert response.json()['errors'][0]['message'] == 'Error accessing OAuth: invalid_code'
 
     @pytest.mark.django_db
     @pytest.mark.parametrize('slack_oauth_request', ['valid_token'], indirect=True)
     @pytest.mark.usefixtures('slack_client', 'slack_oauth_request')
-    def test_valid(self, client):
+    def test_valid(self, client, mutation_generator):
         code = '123456789012.123456789012.1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGHIJKLMNOPQR'
         client_id = '123456789012.123456789012.123456'
         redirect_uri = 'www.app.trystrand.com/install'
-        mutation = f'''
-          mutation {{
-            attemptSlackInstallation(input: {{code: "{code}",
-                                              clientId: "{client_id}", redirectUri: "{redirect_uri}"}}) {{
-              slackTeam {{
-                name
-              }}
-            }}
-          }}
-        '''
+
+        mutation = mutation_generator.attempt_slack_installation(code, client_id, redirect_uri)
         response = client.post('/graphql', {'query': mutation})
+
         assert response.status_code == 200
         assert response.json()['data']['attemptSlackInstallation']['slackTeam']['name'] == 'Clippy Sandbox'

--- a/tests/func/slack_integration/test_attempt_slack_installation.py
+++ b/tests/func/slack_integration/test_attempt_slack_installation.py
@@ -5,7 +5,8 @@ class TestAttemptSlackInstallation:
 
     @pytest.mark.django_db
     @pytest.mark.parametrize('slack_oauth_request', ['invalid_token'], indirect=True)
-    def test_invalid_token(self, client, slack_oauth_request):
+    @pytest.mark.usefixtures('slack_oauth_request')
+    def test_invalid_token(self, client):
         code = '123456789012.123456789012.1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGHIJKLMNOPQR'
         client_id = '123456789012.123456789012.123456'
         redirect_uri = 'www.app.trystrand.com/install'
@@ -25,7 +26,8 @@ class TestAttemptSlackInstallation:
 
     @pytest.mark.django_db
     @pytest.mark.parametrize('slack_oauth_request', ['valid_token'], indirect=True)
-    def test_valid(self, client, slack_client_factory, slack_oauth_request):
+    @pytest.mark.usefixtures('slack_client', 'slack_oauth_request')
+    def test_valid(self, client):
         code = '123456789012.123456789012.1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGHIJKLMNOPQR'
         client_id = '123456789012.123456789012.123456'
         redirect_uri = 'www.app.trystrand.com/install'

--- a/tests/func/slack_integration/test_close_discussion_from_slack.py
+++ b/tests/func/slack_integration/test_close_discussion_from_slack.py
@@ -1,72 +1,69 @@
 import pytest
 
+from tests.resources.MutationGenerator import MutationGenerator
+
 
 class TestCloseDiscussionFromSlack:
 
     @pytest.mark.django_db
-    def test_unauthenticated(self, client, mutation_generator, discussion_factory, slack_channel_factory,
-                             slack_user_factory):
+    def test_unauthenticated(self, client, discussion_factory, slack_channel_factory, slack_user_factory):
         discussion = discussion_factory(topic__is_private=False)
         slack_user = slack_user_factory(is_admin=True)
         slack_channel = slack_channel_factory(discussion=discussion)
 
-        mutation = mutation_generator.close_discussion_from_slack(slack_channel.id, slack_user.id)
+        mutation = MutationGenerator.close_discussion_from_slack(slack_channel.id, slack_user.id)
         response = client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['closeDiscussionFromSlack'] is None
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_invalid_slack_channel(self, auth_client, mutation_generator, discussion_factory, slack_channel_factory,
-                                   slack_user_factory):
+    def test_invalid_slack_channel(self, auth_client, discussion_factory, slack_channel_factory, slack_user_factory):
         discussion = discussion_factory(topic__is_private=False)
         slack_user = slack_user_factory(is_admin=True)
         slack_channel = slack_channel_factory.build(discussion=discussion)
 
-        mutation = mutation_generator.close_discussion_from_slack(slack_channel.id, slack_user.id)
+        mutation = MutationGenerator.close_discussion_from_slack(slack_channel.id, slack_user.id)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['closeDiscussionFromSlack'] is None
         assert response.json()['errors'][0]['message'] == 'Discussion matching query does not exist.'
 
     @pytest.mark.django_db
-    def test_invalid_user(self, auth_client, mutation_generator, discussion_factory, slack_channel_factory,
-                          slack_user_factory):
+    def test_invalid_user(self, auth_client, discussion_factory, slack_channel_factory, slack_user_factory):
         slack_user = slack_user_factory(is_admin=False)
         discussion = discussion_factory(topic__is_private=False)
         slack_channel = slack_channel_factory(discussion=discussion)
 
-        mutation = mutation_generator.close_discussion_from_slack(slack_channel.id, slack_user.id)
+        mutation = MutationGenerator.close_discussion_from_slack(slack_channel.id, slack_user.id)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['closeDiscussionFromSlack'] is None
         assert response.json()['errors'][0]['message'] == 'Slack user does not have permission to close discussion'
 
     @pytest.mark.django_db
-    def test_valid_op(self, auth_client, mutation_generator, discussion_factory, slack_channel_factory,
-                      slack_user_factory):
+    def test_valid_op(self, auth_client, discussion_factory, slack_channel_factory, slack_user_factory):
         slack_user = slack_user_factory()
         discussion = discussion_factory(topic__is_private=False, topic__original_poster=slack_user.user)
         slack_channel = slack_channel_factory(discussion=discussion)
 
-        mutation = mutation_generator.close_discussion_from_slack(slack_channel.id, slack_user.id)
+        mutation = MutationGenerator.close_discussion_from_slack(slack_channel.id, slack_user.id)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['closeDiscussionFromSlack']['discussion']['status'] == 'CLOSED'
 
     @pytest.mark.django_db
-    def test_valid_admin(self, auth_client, mutation_generator, discussion_factory, slack_channel_factory,
-                         slack_user_factory):
+    def test_valid_admin(self, auth_client, discussion_factory, slack_channel_factory, slack_user_factory):
         discussion = discussion_factory(topic__is_private=False)
         slack_user = slack_user_factory(is_admin=True)
         slack_channel = slack_channel_factory(discussion=discussion)
 
-        mutation = mutation_generator.close_discussion_from_slack(slack_channel.id, slack_user.id)
+        mutation = MutationGenerator.close_discussion_from_slack(slack_channel.id, slack_user.id)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['closeDiscussionFromSlack']['discussion']['status'] == 'CLOSED'

--- a/tests/func/slack_integration/test_create_discussion_from_slack.py
+++ b/tests/func/slack_integration/test_create_discussion_from_slack.py
@@ -1,36 +1,38 @@
 import pytest
 
+from tests.resources.MutationGenerator import MutationGenerator
+
 
 class TestCreateDiscussionFromSlack:
 
     @pytest.mark.django_db
-    def test_unauthenticated(self, client, mutation_generator, slack_channel_factory, slack_team_factory,
+    def test_unauthenticated(self, client, slack_channel_factory, slack_team_factory,
                              discussion_factory, topic_factory):
         topic = topic_factory(is_private=False)
         slack_team = slack_team_factory()
         discussion = discussion_factory.build()
         slack_channel = slack_channel_factory.build()
 
-        mutation = mutation_generator.create_discussion_from_slack(discussion.time_start, topic.id, slack_channel.id,
-                                                                   slack_channel.name, slack_team.id)
+        mutation = MutationGenerator.create_discussion_from_slack(discussion.time_start, topic.id, slack_channel.id,
+                                                                  slack_channel.name, slack_team.id)
         response = client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createDiscussionFromSlack'] is None
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_valid(self, auth_client, mutation_generator, slack_channel_factory, slack_team_factory, discussion_factory,
+    def test_valid(self, auth_client, slack_channel_factory, slack_team_factory, discussion_factory,
                    topic_factory):
         topic = topic_factory(is_private=False)
         slack_team = slack_team_factory()
         discussion = discussion_factory.build()
         slack_channel = slack_channel_factory.build()
 
-        mutation = mutation_generator.create_discussion_from_slack(discussion.time_start, topic.id, slack_channel.id,
-                                                                   slack_channel.name, slack_team.id)
+        mutation = MutationGenerator.create_discussion_from_slack(discussion.time_start, topic.id, slack_channel.id,
+                                                                  slack_channel.name, slack_team.id)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createDiscussionFromSlack']['discussion']['topic']['id'] == str(topic.id)
         assert response.json()['data']['createDiscussionFromSlack']['slackChannel']['name'] == slack_channel.name

--- a/tests/func/slack_integration/test_create_discussion_from_slack.py
+++ b/tests/func/slack_integration/test_create_discussion_from_slack.py
@@ -4,29 +4,15 @@ import pytest
 class TestCreateDiscussionFromSlack:
 
     @pytest.mark.django_db
-    def test_unauthenticated(self, client, slack_channel_factory, slack_team_factory, discussion_factory,
-                             topic_factory):
+    def test_unauthenticated(self, client, mutation_generator, slack_channel_factory, slack_team_factory,
+                             discussion_factory, topic_factory):
         topic = topic_factory(is_private=False)
         slack_team = slack_team_factory()
         discussion = discussion_factory.build()
         slack_channel = slack_channel_factory.build()
 
-        mutation = f'''
-          mutation {{
-            createDiscussionFromSlack(input: {{discussion: {{timeStart: "{discussion.time_start}",
-                                                       topicId: {topic.id}}},
-                                                       id: "{slack_channel.id}",
-                                                       name: "{slack_channel.name}",
-                                                       slackTeamId: "{slack_team.id}"}}) {{
-              discussion {{
-                id
-              }}
-              slackChannel {{
-                name
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_discussion_from_slack(discussion.time_start, topic.id, slack_channel.id,
+                                                                   slack_channel.name, slack_team.id)
         response = client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200
@@ -34,30 +20,15 @@ class TestCreateDiscussionFromSlack:
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_valid(self, auth_client, slack_channel_factory, slack_team_factory, discussion_factory, topic_factory):
+    def test_valid(self, auth_client, mutation_generator, slack_channel_factory, slack_team_factory, discussion_factory,
+                   topic_factory):
         topic = topic_factory(is_private=False)
         slack_team = slack_team_factory()
         discussion = discussion_factory.build()
         slack_channel = slack_channel_factory.build()
 
-        mutation = f'''
-          mutation {{
-            createDiscussionFromSlack(input: {{discussion: {{timeStart: "{discussion.time_start}",
-                                                       topicId: {topic.id}}},
-                                                       id: "{slack_channel.id}",
-                                                       name: "{slack_channel.name}",
-                                                       slackTeamId: "{slack_team.id}"}}) {{
-              discussion {{
-                topic {{
-                  id
-                }}
-              }}
-              slackChannel {{
-                name
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_discussion_from_slack(discussion.time_start, topic.id, slack_channel.id,
+                                                                   slack_channel.name, slack_team.id)
         response = auth_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200

--- a/tests/func/slack_integration/test_create_message_from_slack.py
+++ b/tests/func/slack_integration/test_create_message_from_slack.py
@@ -1,9 +1,11 @@
 import pytest
 
+from tests.resources.MutationGenerator import MutationGenerator
+
 
 class TestCreateMessageFromSlack:
     @pytest.mark.django_db
-    def test_unauthenticated(self, client, mutation_generator, slack_channel_factory, user_factory, slack_user_factory,
+    def test_unauthenticated(self, client, slack_channel_factory, user_factory, slack_user_factory,
                              slack_event_factory, message_factory):
         slack_channel = slack_channel_factory(discussion__topic__is_private=False)
         user = user_factory()
@@ -12,18 +14,18 @@ class TestCreateMessageFromSlack:
         slack_event = slack_event_factory.build()
         message = message_factory.build()
 
-        mutation = mutation_generator.create_message_from_slack(text=message.text,
-                                                                slack_channel_id=slack_channel.id,
-                                                                slack_user_id=slack_user.id,
-                                                                origin_slack_event_ts=slack_event.ts)
+        mutation = MutationGenerator.create_message_from_slack(text=message.text,
+                                                               slack_channel_id=slack_channel.id,
+                                                               slack_user_id=slack_user.id,
+                                                               origin_slack_event_ts=slack_event.ts)
         response = client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createMessageFromSlack'] is None
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_invalid_slack_user(self, auth_client, mutation_generator, slack_channel_factory, user_factory,
+    def test_invalid_slack_user(self, auth_client, slack_channel_factory, user_factory,
                                 slack_user_factory, slack_event_factory, message_factory):
         slack_channel = slack_channel_factory(discussion__topic__is_private=False)
         user = user_factory()
@@ -32,18 +34,18 @@ class TestCreateMessageFromSlack:
         slack_event = slack_event_factory.build()
         message = message_factory.build()
 
-        mutation = mutation_generator.create_message_from_slack(text=message.text,
-                                                                slack_channel_id=slack_channel.id,
-                                                                slack_user_id=slack_user.id,
-                                                                origin_slack_event_ts=slack_event.ts)
+        mutation = MutationGenerator.create_message_from_slack(text=message.text,
+                                                               slack_channel_id=slack_channel.id,
+                                                               slack_user_id=slack_user.id,
+                                                               origin_slack_event_ts=slack_event.ts)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createMessageFromSlack'] is None
         assert response.json()['errors'][0]['message'] == 'User matching query does not exist.'
 
     @pytest.mark.django_db
-    def test_invalid_slack_channel(self, auth_client, mutation_generator, slack_channel_factory, user_factory,
+    def test_invalid_slack_channel(self, auth_client, slack_channel_factory, user_factory,
                                    slack_user_factory, slack_event_factory, message_factory):
         slack_channel = slack_channel_factory.build()
         user = user_factory()
@@ -52,18 +54,18 @@ class TestCreateMessageFromSlack:
         slack_event = slack_event_factory.build()
         message = message_factory.build()
 
-        mutation = mutation_generator.create_message_from_slack(text=message.text,
-                                                                slack_channel_id=slack_channel.id,
-                                                                slack_user_id=slack_user.id,
-                                                                origin_slack_event_ts=slack_event.ts)
+        mutation = MutationGenerator.create_message_from_slack(text=message.text,
+                                                               slack_channel_id=slack_channel.id,
+                                                               slack_user_id=slack_user.id,
+                                                               origin_slack_event_ts=slack_event.ts)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createMessageFromSlack'] is None
         assert response.json()['errors'][0]['message'] == 'Discussion matching query does not exist.'
 
     @pytest.mark.django_db
-    def test_valid(self, auth_client, mutation_generator, discussion_factory, slack_channel_factory, user_factory,
+    def test_valid(self, auth_client, discussion_factory, slack_channel_factory, user_factory,
                    slack_user_factory, slack_event_factory, message_factory):
         discussion = discussion_factory(topic__is_private=False)
         slack_channel = slack_channel_factory(discussion=discussion)
@@ -73,13 +75,13 @@ class TestCreateMessageFromSlack:
         slack_event = slack_event_factory.build()
         message = message_factory.build()
 
-        mutation = mutation_generator.create_message_from_slack(text=message.text,
-                                                                slack_channel_id=slack_channel.id,
-                                                                slack_user_id=slack_user.id,
-                                                                origin_slack_event_ts=slack_event.ts)
+        mutation = MutationGenerator.create_message_from_slack(text=message.text,
+                                                               slack_channel_id=slack_channel.id,
+                                                               slack_user_id=slack_user.id,
+                                                               origin_slack_event_ts=slack_event.ts)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createMessageFromSlack']['message']['author']['id'] == \
             str(slack_user.user.id)
         assert response.json()['data']['createMessageFromSlack']['message']['discussion']['id'] == str(discussion.id)

--- a/tests/func/slack_integration/test_create_message_from_slack.py
+++ b/tests/func/slack_integration/test_create_message_from_slack.py
@@ -3,7 +3,7 @@ import pytest
 
 class TestCreateMessageFromSlack:
     @pytest.mark.django_db
-    def test_unauthenticated(self, client, slack_channel_factory, user_factory, slack_user_factory,
+    def test_unauthenticated(self, client, mutation_generator, slack_channel_factory, user_factory, slack_user_factory,
                              slack_event_factory, message_factory):
         slack_channel = slack_channel_factory(discussion__topic__is_private=False)
         user = user_factory()
@@ -12,17 +12,10 @@ class TestCreateMessageFromSlack:
         slack_event = slack_event_factory.build()
         message = message_factory.build()
 
-        mutation = f'''
-          mutation {{
-            createMessageFromSlack(input: {{text: "{message.text}",
-                                            slackChannelId: "{slack_channel.id}", slackUserId: "{slack_user.id}",
-                                            originSlackEventTs: "{slack_event.ts}"}}) {{
-              message {{
-                text
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_message_from_slack(text=message.text,
+                                                                slack_channel_id=slack_channel.id,
+                                                                slack_user_id=slack_user.id,
+                                                                origin_slack_event_ts=slack_event.ts)
         response = client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200
@@ -30,7 +23,7 @@ class TestCreateMessageFromSlack:
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_invalid_slack_user(self, auth_client, slack_channel_factory, user_factory,
+    def test_invalid_slack_user(self, auth_client, mutation_generator, slack_channel_factory, user_factory,
                                 slack_user_factory, slack_event_factory, message_factory):
         slack_channel = slack_channel_factory(discussion__topic__is_private=False)
         user = user_factory()
@@ -39,17 +32,10 @@ class TestCreateMessageFromSlack:
         slack_event = slack_event_factory.build()
         message = message_factory.build()
 
-        mutation = f'''
-          mutation {{
-            createMessageFromSlack(input: {{text: "{message.text}",
-                                            slackChannelId: "{slack_channel.id}", slackUserId: "{slack_user.id}",
-                                            originSlackEventTs: "{slack_event.ts}"}}) {{
-              message {{
-                text
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_message_from_slack(text=message.text,
+                                                                slack_channel_id=slack_channel.id,
+                                                                slack_user_id=slack_user.id,
+                                                                origin_slack_event_ts=slack_event.ts)
         response = auth_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200
@@ -57,7 +43,7 @@ class TestCreateMessageFromSlack:
         assert response.json()['errors'][0]['message'] == 'User matching query does not exist.'
 
     @pytest.mark.django_db
-    def test_invalid_slack_channel(self, auth_client, slack_channel_factory, user_factory,
+    def test_invalid_slack_channel(self, auth_client, mutation_generator, slack_channel_factory, user_factory,
                                    slack_user_factory, slack_event_factory, message_factory):
         slack_channel = slack_channel_factory.build()
         user = user_factory()
@@ -66,17 +52,10 @@ class TestCreateMessageFromSlack:
         slack_event = slack_event_factory.build()
         message = message_factory.build()
 
-        mutation = f'''
-          mutation {{
-            createMessageFromSlack(input: {{text: "{message.text}",
-                                            slackChannelId: "{slack_channel.id}", slackUserId: "{slack_user.id}",
-                                            originSlackEventTs: "{slack_event.ts}"}}) {{
-              message {{
-                text
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_message_from_slack(text=message.text,
+                                                                slack_channel_id=slack_channel.id,
+                                                                slack_user_id=slack_user.id,
+                                                                origin_slack_event_ts=slack_event.ts)
         response = auth_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200
@@ -84,7 +63,7 @@ class TestCreateMessageFromSlack:
         assert response.json()['errors'][0]['message'] == 'Discussion matching query does not exist.'
 
     @pytest.mark.django_db
-    def test_valid(self, auth_client, discussion_factory, slack_channel_factory, user_factory,
+    def test_valid(self, auth_client, mutation_generator, discussion_factory, slack_channel_factory, user_factory,
                    slack_user_factory, slack_event_factory, message_factory):
         discussion = discussion_factory(topic__is_private=False)
         slack_channel = slack_channel_factory(discussion=discussion)
@@ -94,25 +73,10 @@ class TestCreateMessageFromSlack:
         slack_event = slack_event_factory.build()
         message = message_factory.build()
 
-        mutation = f'''
-          mutation {{
-            createMessageFromSlack(input: {{text: "{message.text}",
-                                            slackChannelId: "{slack_channel.id}", slackUserId: "{slack_user.id}",
-                                            originSlackEventTs: "{slack_event.ts}"}}) {{
-              message {{
-                author {{
-                  id
-                }}
-                discussion {{
-                  id
-                  participants {{
-                    id
-                  }}
-                }}
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_message_from_slack(text=message.text,
+                                                                slack_channel_id=slack_channel.id,
+                                                                slack_user_id=slack_user.id,
+                                                                origin_slack_event_ts=slack_event.ts)
         response = auth_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200

--- a/tests/func/slack_integration/test_create_reply_from_slack.py
+++ b/tests/func/slack_integration/test_create_reply_from_slack.py
@@ -7,7 +7,7 @@ import pytest
 class TestCreateReplyFromSlack:
 
     @pytest.mark.django_db
-    def test_unauthenticated(self, client, slack_channel_factory, slack_event_factory,
+    def test_unauthenticated(self, client, mutation_generator, slack_channel_factory, slack_event_factory,
                              slack_user_factory, message_factory, reply_factory):
         slack_channel = slack_channel_factory(discussion__topic__is_private=False)
         message_slack_user = slack_user_factory()
@@ -19,23 +19,11 @@ class TestCreateReplyFromSlack:
         reply = reply_factory.build(message=message, author=reply_slack_user.user)
         reply_slack_event = slack_event_factory.build()
 
-        mutation = f'''
-          mutation {{
-            createReplyFromSlack(input: {{text: "{reply.text}",
-                                          messageOriginSlackEventTs: "{message_slack_event.ts}",
-                                          slackChannelId: "{slack_channel.id}",
-                                          slackUserId: "{reply_slack_user.id}",
-                                          originSlackEventTs: "{reply_slack_event.ts}"}}) {{
-              reply {{
-                message {{
-                  author {{
-                    id
-                  }}
-                }}
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_reply_from_slack(text=reply.text,
+                                                              message_origin_slack_event_ts=message_slack_event.ts,
+                                                              slack_channel_id=slack_channel.id,
+                                                              slack_user_id=reply_slack_user.id,
+                                                              origin_slack_event_ts=reply_slack_event.ts)
         response = client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200
@@ -43,13 +31,12 @@ class TestCreateReplyFromSlack:
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_invalid_slack_channel(self, auth_client, discussion_factory, slack_channel_factory, slack_event_factory,
+    def test_invalid_slack_channel(self, auth_client, mutation_generator, slack_channel_factory, slack_event_factory,
                                    slack_user_factory, message_factory, reply_factory):
-        discussion = discussion_factory(topic__is_private=False)
         slack_channel = slack_channel_factory.build()
 
         message_slack_user = slack_user_factory()
-        message = message_factory(discussion=discussion,
+        message = message_factory(discussion__topic__is_private=False,
                                   author=message_slack_user.user)
         message_slack_event = slack_event_factory(message=message)
 
@@ -57,23 +44,11 @@ class TestCreateReplyFromSlack:
         reply = reply_factory.build(message=message, author=reply_slack_user.user)
         reply_slack_event = slack_event_factory.build()
 
-        mutation = f'''
-          mutation {{
-            createReplyFromSlack(input: {{text: "{reply.text}",
-                                          messageOriginSlackEventTs: "{message_slack_event.ts}",
-                                          slackChannelId: "{slack_channel.id}",
-                                          slackUserId: "{reply_slack_user.id}",
-                                          originSlackEventTs: "{reply_slack_event.ts}"}}) {{
-              reply {{
-                message {{
-                  author {{
-                    id
-                  }}
-                }}
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_reply_from_slack(text=reply.text,
+                                                              message_origin_slack_event_ts=message_slack_event.ts,
+                                                              slack_channel_id=slack_channel.id,
+                                                              slack_user_id=reply_slack_user.id,
+                                                              origin_slack_event_ts=reply_slack_event.ts)
         response = auth_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200
@@ -81,7 +56,7 @@ class TestCreateReplyFromSlack:
         assert response.json()['errors'][0]['message'] == 'Message matching query does not exist.'
 
     @pytest.mark.django_db
-    def test_invalid_slack_user(self, auth_client, slack_channel_factory, slack_event_factory,
+    def test_invalid_slack_user(self, auth_client, mutation_generator, slack_channel_factory, slack_event_factory,
                                 slack_user_factory, message_factory, reply_factory):
         slack_channel = slack_channel_factory(discussion__topic__is_private=False)
 
@@ -94,23 +69,11 @@ class TestCreateReplyFromSlack:
         reply = reply_factory.build(message=message, author=reply_slack_user.user)
         reply_slack_event = slack_event_factory.build()
 
-        mutation = f'''
-          mutation {{
-            createReplyFromSlack(input: {{text: "{reply.text}",
-                                          messageOriginSlackEventTs: "{message_slack_event.ts}",
-                                          slackChannelId: "{slack_channel.id}",
-                                          slackUserId: "{reply_slack_user.id}",
-                                          originSlackEventTs: "{reply_slack_event.ts}"}}) {{
-              reply {{
-                message {{
-                  author {{
-                    id
-                  }}
-                }}
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_reply_from_slack(text=reply.text,
+                                                              message_origin_slack_event_ts=message_slack_event.ts,
+                                                              slack_channel_id=slack_channel.id,
+                                                              slack_user_id=reply_slack_user.id,
+                                                              origin_slack_event_ts=reply_slack_event.ts)
         response = auth_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200
@@ -118,9 +81,9 @@ class TestCreateReplyFromSlack:
         assert response.json()['errors'][0]['message'] == 'User matching query does not exist.'
 
     @pytest.mark.django_db
-    def test_create_invalid_message_slack_event(self, auth_client, slack_channel_factory,
-                                                slack_event_factory, slack_user_factory,
-                                                message_factory, reply_factory):
+    def test_create_invalid_message_slack_event(self, auth_client, mutation_generator, slack_channel_factory,
+                                                slack_event_factory, slack_user_factory, message_factory,
+                                                reply_factory):
         slack_channel = slack_channel_factory(discussion__topic__is_private=False)
 
         message_slack_user = slack_user_factory()
@@ -132,23 +95,11 @@ class TestCreateReplyFromSlack:
         reply = reply_factory.build(message=message, author=reply_slack_user.user)
         reply_slack_event = slack_event_factory.build()
 
-        mutation = f'''
-          mutation {{
-            createReplyFromSlack(input: {{text: "{reply.text}",
-                                          messageOriginSlackEventTs: "{message_slack_event.ts}",
-                                          slackChannelId: "{slack_channel.id}",
-                                          slackUserId: "{reply_slack_user.id}",
-                                          originSlackEventTs: "{reply_slack_event.ts}"}}) {{
-              reply {{
-                message {{
-                  author {{
-                    id
-                  }}
-                }}
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_reply_from_slack(text=reply.text,
+                                                              message_origin_slack_event_ts=message_slack_event.ts,
+                                                              slack_channel_id=slack_channel.id,
+                                                              slack_user_id=reply_slack_user.id,
+                                                              origin_slack_event_ts=reply_slack_event.ts)
         response = auth_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200
@@ -156,8 +107,8 @@ class TestCreateReplyFromSlack:
         assert response.json()['errors'][0]['message'] == 'Message matching query does not exist.'
 
     @pytest.mark.django_db
-    def test_valid(self, auth_client, slack_channel_factory, slack_event_factory, slack_user_factory,
-                   message_factory, reply_factory):
+    def test_valid(self, auth_client, mutation_generator, slack_channel_factory, slack_event_factory,
+                   slack_user_factory, message_factory, reply_factory):
         slack_channel = slack_channel_factory(discussion__topic__is_private=False)
 
         message_slack_user = slack_user_factory()
@@ -169,29 +120,11 @@ class TestCreateReplyFromSlack:
         reply = reply_factory.build(message=message, author=reply_slack_user.user)
         reply_slack_event = slack_event_factory.build()
 
-        mutation = f'''
-          mutation {{
-            createReplyFromSlack(input: {{text: "{reply.text}",
-                                          messageOriginSlackEventTs: "{message_slack_event.ts}",
-                                          slackChannelId: "{slack_channel.id}",
-                                          slackUserId: "{reply_slack_user.id}",
-                                          originSlackEventTs: "{reply_slack_event.ts}"}}) {{
-              reply {{
-                time
-                message {{
-                  author {{
-                    id
-                  }}
-                  discussion {{
-                    participants {{
-                      id
-                    }}
-                  }}
-                }}
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_reply_from_slack(text=reply.text,
+                                                              message_origin_slack_event_ts=message_slack_event.ts,
+                                                              slack_channel_id=slack_channel.id,
+                                                              slack_user_id=reply_slack_user.id,
+                                                              origin_slack_event_ts=reply_slack_event.ts)
         response = auth_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200

--- a/tests/func/slack_integration/test_create_reply_from_slack.py
+++ b/tests/func/slack_integration/test_create_reply_from_slack.py
@@ -3,11 +3,13 @@ import pytz
 
 import pytest
 
+from tests.resources.MutationGenerator import MutationGenerator
+
 
 class TestCreateReplyFromSlack:
 
     @pytest.mark.django_db
-    def test_unauthenticated(self, client, mutation_generator, slack_channel_factory, slack_event_factory,
+    def test_unauthenticated(self, client, slack_channel_factory, slack_event_factory,
                              slack_user_factory, message_factory, reply_factory):
         slack_channel = slack_channel_factory(discussion__topic__is_private=False)
         message_slack_user = slack_user_factory()
@@ -19,19 +21,19 @@ class TestCreateReplyFromSlack:
         reply = reply_factory.build(message=message, author=reply_slack_user.user)
         reply_slack_event = slack_event_factory.build()
 
-        mutation = mutation_generator.create_reply_from_slack(text=reply.text,
-                                                              message_origin_slack_event_ts=message_slack_event.ts,
-                                                              slack_channel_id=slack_channel.id,
-                                                              slack_user_id=reply_slack_user.id,
-                                                              origin_slack_event_ts=reply_slack_event.ts)
+        mutation = MutationGenerator.create_reply_from_slack(text=reply.text,
+                                                             message_origin_slack_event_ts=message_slack_event.ts,
+                                                             slack_channel_id=slack_channel.id,
+                                                             slack_user_id=reply_slack_user.id,
+                                                             origin_slack_event_ts=reply_slack_event.ts)
         response = client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createReplyFromSlack'] is None
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_invalid_slack_channel(self, auth_client, mutation_generator, slack_channel_factory, slack_event_factory,
+    def test_invalid_slack_channel(self, auth_client, slack_channel_factory, slack_event_factory,
                                    slack_user_factory, message_factory, reply_factory):
         slack_channel = slack_channel_factory.build()
 
@@ -44,19 +46,19 @@ class TestCreateReplyFromSlack:
         reply = reply_factory.build(message=message, author=reply_slack_user.user)
         reply_slack_event = slack_event_factory.build()
 
-        mutation = mutation_generator.create_reply_from_slack(text=reply.text,
-                                                              message_origin_slack_event_ts=message_slack_event.ts,
-                                                              slack_channel_id=slack_channel.id,
-                                                              slack_user_id=reply_slack_user.id,
-                                                              origin_slack_event_ts=reply_slack_event.ts)
+        mutation = MutationGenerator.create_reply_from_slack(text=reply.text,
+                                                             message_origin_slack_event_ts=message_slack_event.ts,
+                                                             slack_channel_id=slack_channel.id,
+                                                             slack_user_id=reply_slack_user.id,
+                                                             origin_slack_event_ts=reply_slack_event.ts)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createReplyFromSlack'] is None
         assert response.json()['errors'][0]['message'] == 'Message matching query does not exist.'
 
     @pytest.mark.django_db
-    def test_invalid_slack_user(self, auth_client, mutation_generator, slack_channel_factory, slack_event_factory,
+    def test_invalid_slack_user(self, auth_client, slack_channel_factory, slack_event_factory,
                                 slack_user_factory, message_factory, reply_factory):
         slack_channel = slack_channel_factory(discussion__topic__is_private=False)
 
@@ -69,19 +71,19 @@ class TestCreateReplyFromSlack:
         reply = reply_factory.build(message=message, author=reply_slack_user.user)
         reply_slack_event = slack_event_factory.build()
 
-        mutation = mutation_generator.create_reply_from_slack(text=reply.text,
-                                                              message_origin_slack_event_ts=message_slack_event.ts,
-                                                              slack_channel_id=slack_channel.id,
-                                                              slack_user_id=reply_slack_user.id,
-                                                              origin_slack_event_ts=reply_slack_event.ts)
+        mutation = MutationGenerator.create_reply_from_slack(text=reply.text,
+                                                             message_origin_slack_event_ts=message_slack_event.ts,
+                                                             slack_channel_id=slack_channel.id,
+                                                             slack_user_id=reply_slack_user.id,
+                                                             origin_slack_event_ts=reply_slack_event.ts)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createReplyFromSlack'] is None
         assert response.json()['errors'][0]['message'] == 'User matching query does not exist.'
 
     @pytest.mark.django_db
-    def test_create_invalid_message_slack_event(self, auth_client, mutation_generator, slack_channel_factory,
+    def test_create_invalid_message_slack_event(self, auth_client, slack_channel_factory,
                                                 slack_event_factory, slack_user_factory, message_factory,
                                                 reply_factory):
         slack_channel = slack_channel_factory(discussion__topic__is_private=False)
@@ -95,19 +97,19 @@ class TestCreateReplyFromSlack:
         reply = reply_factory.build(message=message, author=reply_slack_user.user)
         reply_slack_event = slack_event_factory.build()
 
-        mutation = mutation_generator.create_reply_from_slack(text=reply.text,
-                                                              message_origin_slack_event_ts=message_slack_event.ts,
-                                                              slack_channel_id=slack_channel.id,
-                                                              slack_user_id=reply_slack_user.id,
-                                                              origin_slack_event_ts=reply_slack_event.ts)
+        mutation = MutationGenerator.create_reply_from_slack(text=reply.text,
+                                                             message_origin_slack_event_ts=message_slack_event.ts,
+                                                             slack_channel_id=slack_channel.id,
+                                                             slack_user_id=reply_slack_user.id,
+                                                             origin_slack_event_ts=reply_slack_event.ts)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createReplyFromSlack'] is None
         assert response.json()['errors'][0]['message'] == 'Message matching query does not exist.'
 
     @pytest.mark.django_db
-    def test_valid(self, auth_client, mutation_generator, slack_channel_factory, slack_event_factory,
+    def test_valid(self, auth_client, slack_channel_factory, slack_event_factory,
                    slack_user_factory, message_factory, reply_factory):
         slack_channel = slack_channel_factory(discussion__topic__is_private=False)
 
@@ -120,14 +122,14 @@ class TestCreateReplyFromSlack:
         reply = reply_factory.build(message=message, author=reply_slack_user.user)
         reply_slack_event = slack_event_factory.build()
 
-        mutation = mutation_generator.create_reply_from_slack(text=reply.text,
-                                                              message_origin_slack_event_ts=message_slack_event.ts,
-                                                              slack_channel_id=slack_channel.id,
-                                                              slack_user_id=reply_slack_user.id,
-                                                              origin_slack_event_ts=reply_slack_event.ts)
+        mutation = MutationGenerator.create_reply_from_slack(text=reply.text,
+                                                             message_origin_slack_event_ts=message_slack_event.ts,
+                                                             slack_channel_id=slack_channel.id,
+                                                             slack_user_id=reply_slack_user.id,
+                                                             origin_slack_event_ts=reply_slack_event.ts)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createReplyFromSlack']['reply']['time'] == \
             datetime.fromtimestamp(int(reply_slack_event.ts), tz=pytz.utc).isoformat()
         assert response.json()['data']['createReplyFromSlack']['reply']['message']['author']['id'] == \

--- a/tests/func/slack_integration/test_create_slack_channel.py
+++ b/tests/func/slack_integration/test_create_slack_channel.py
@@ -1,63 +1,65 @@
 import pytest
 
+from tests.resources.MutationGenerator import MutationGenerator
+
 
 class TestCreateSlackChannel:
 
     @pytest.mark.django_db
-    def test_unauthenticated(self, client, mutation_generator, slack_channel_factory, slack_team_factory,
+    def test_unauthenticated(self, client, slack_channel_factory, slack_team_factory,
                              discussion_factory):
         discussion = discussion_factory()
         slack_team = slack_team_factory()
         slack_channel = slack_channel_factory.build()
 
-        mutation = mutation_generator.create_slack_channel(id=slack_channel.id, name=slack_channel.name,
-                                                           slack_team_id=slack_team.id, discussion_id=discussion.id)
+        mutation = MutationGenerator.create_slack_channel(id=slack_channel.id, name=slack_channel.name,
+                                                          slack_team_id=slack_team.id, discussion_id=discussion.id)
         response = client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createSlackChannel'] is None
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_invalid_team(self, auth_client, mutation_generator, slack_channel_factory, slack_team_factory,
+    def test_invalid_team(self, auth_client, slack_channel_factory, slack_team_factory,
                           discussion_factory):
         discussion = discussion_factory()
         slack_team = slack_team_factory.build()
         slack_channel = slack_channel_factory.build()
 
-        mutation = mutation_generator.create_slack_channel(id=slack_channel.id, name=slack_channel.name,
-                                                           slack_team_id=slack_team.id, discussion_id=discussion.id)
+        mutation = MutationGenerator.create_slack_channel(id=slack_channel.id, name=slack_channel.name,
+                                                          slack_team_id=slack_team.id, discussion_id=discussion.id)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createSlackChannel'] is None
         assert response.json()['errors'][0]['message'] == f"{{'slack_team_id': ['Invalid pk \"{slack_team.id}\" - " \
                                                           "object does not exist.']}"
 
     @pytest.mark.django_db
-    def test_invalid_discussion(self, auth_client, mutation_generator, slack_channel_factory, slack_team_factory):
+    def test_invalid_discussion(self, auth_client, slack_channel_factory, slack_team_factory):
         slack_team = slack_team_factory()
         slack_channel = slack_channel_factory.build()
 
-        mutation = mutation_generator.create_slack_channel(id=slack_channel.id, name=slack_channel.name,
-                                                           slack_team_id=slack_team.id, discussion_id=0)
+        mutation = MutationGenerator.create_slack_channel(id=slack_channel.id, name=slack_channel.name,
+                                                          slack_team_id=slack_team.id, discussion_id=0)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createSlackChannel'] is None
         assert response.json()['errors'][0]['message'] == "{'discussion_id': ['Invalid pk \"0\" - " \
                                                           "object does not exist.']}"
 
     @pytest.mark.django_db
-    def test_valid(self, auth_client, mutation_generator, slack_channel_factory, slack_team_factory,
+    def test_valid(self, auth_client, slack_channel_factory, slack_team_factory,
                    discussion_factory):
         discussion = discussion_factory()
         slack_team = slack_team_factory()
         slack_channel = slack_channel_factory.build()
 
-        mutation = mutation_generator.create_slack_channel(id=slack_channel.id, name=slack_channel.name,
-                                                           slack_team_id=slack_team.id, discussion_id=discussion.id)
+        mutation = MutationGenerator.create_slack_channel(id=slack_channel.id, name=slack_channel.name,
+                                                          slack_team_id=slack_team.id, discussion_id=discussion.id)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createSlackChannel']['slackChannel']['name'] == slack_channel.name

--- a/tests/func/slack_integration/test_create_slack_channel.py
+++ b/tests/func/slack_integration/test_create_slack_channel.py
@@ -4,21 +4,14 @@ import pytest
 class TestCreateSlackChannel:
 
     @pytest.mark.django_db
-    def test_unauthenticated(self, client, slack_channel_factory, slack_team_factory, discussion_factory):
+    def test_unauthenticated(self, client, mutation_generator, slack_channel_factory, slack_team_factory,
+                             discussion_factory):
         discussion = discussion_factory()
         slack_team = slack_team_factory()
         slack_channel = slack_channel_factory.build()
 
-        mutation = f'''
-          mutation {{
-            createSlackChannel(input: {{id: "{slack_channel.id}", name: "{slack_channel.name}",
-                                        slackTeamId: "{slack_team.id}", discussionId: {discussion.id}}}) {{
-              slackChannel {{
-                name
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_slack_channel(id=slack_channel.id, name=slack_channel.name,
+                                                           slack_team_id=slack_team.id, discussion_id=discussion.id)
         response = client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200
@@ -26,21 +19,14 @@ class TestCreateSlackChannel:
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_invalid_team(self, auth_client, slack_channel_factory, slack_team_factory, discussion_factory):
+    def test_invalid_team(self, auth_client, mutation_generator, slack_channel_factory, slack_team_factory,
+                          discussion_factory):
         discussion = discussion_factory()
         slack_team = slack_team_factory.build()
         slack_channel = slack_channel_factory.build()
 
-        mutation = f'''
-          mutation {{
-            createSlackChannel(input: {{id: "{slack_channel.id}", name: "{slack_channel.name}",
-                                        slackTeamId: "{slack_team.id}", discussionId: {discussion.id}}}) {{
-              slackChannel {{
-                name
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_slack_channel(id=slack_channel.id, name=slack_channel.name,
+                                                           slack_team_id=slack_team.id, discussion_id=discussion.id)
         response = auth_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200
@@ -49,20 +35,12 @@ class TestCreateSlackChannel:
                                                           "object does not exist.']}"
 
     @pytest.mark.django_db
-    def test_invalid_discussion(self, auth_client, slack_channel_factory, slack_team_factory):
+    def test_invalid_discussion(self, auth_client, mutation_generator, slack_channel_factory, slack_team_factory):
         slack_team = slack_team_factory()
         slack_channel = slack_channel_factory.build()
 
-        mutation = f'''
-          mutation {{
-            createSlackChannel(input: {{id: "{slack_channel.id}", name: "{slack_channel.name}",
-                                        slackTeamId: "{slack_team.id}", discussionId: 0}}) {{
-              slackChannel {{
-                name
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_slack_channel(id=slack_channel.id, name=slack_channel.name,
+                                                           slack_team_id=slack_team.id, discussion_id=0)
         response = auth_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200
@@ -71,21 +49,14 @@ class TestCreateSlackChannel:
                                                           "object does not exist.']}"
 
     @pytest.mark.django_db
-    def test_valid(self, auth_client, slack_channel_factory, slack_team_factory, discussion_factory):
+    def test_valid(self, auth_client, mutation_generator, slack_channel_factory, slack_team_factory,
+                   discussion_factory):
         discussion = discussion_factory()
         slack_team = slack_team_factory()
         slack_channel = slack_channel_factory.build()
 
-        mutation = f'''
-          mutation {{
-            createSlackChannel(input: {{id: "{slack_channel.id}", name: "{slack_channel.name}",
-                                        slackTeamId: "{slack_team.id}", discussionId: {discussion.id}}}) {{
-              slackChannel {{
-                name
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_slack_channel(id=slack_channel.id, name=slack_channel.name,
+                                                           slack_team_id=slack_team.id, discussion_id=discussion.id)
         response = auth_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200

--- a/tests/func/slack_integration/test_create_slack_user.py
+++ b/tests/func/slack_integration/test_create_slack_user.py
@@ -4,97 +4,72 @@ import pytest
 class TestCreateSlackUser:
 
     @pytest.mark.django_db
-    def test_unauthenticated(self, client, user_factory, slack_team_factory, slack_user_factory):
+    def test_unauthenticated(self, client, mutation_generator, user_factory, slack_team_factory, slack_user_factory):
         user = user_factory()
         slack_team = slack_team_factory()
         slack_user = slack_user_factory.build()
 
-        mutation = f'''
-          mutation {{
-            createSlackUser(input: {{id: "{slack_user.id}", name: "{slack_user.name}",
-                                     realName: "{slack_user.real_name}", displayName: "{slack_user.display_name}",
-                                     image72: "{slack_user.image_72}", isBot: {str(slack_user.is_bot).lower()},
-                                     isAdmin: {str(slack_user.is_admin).lower()}, slackTeamId: "{slack_team.id}",
-                                     userId: {user.id}}}) {{
-              slackUser {{
-                id
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_slack_user(id=slack_user.id, name=slack_user.name,
+                                                        real_name=slack_user.real_name,
+                                                        display_name=slack_user.display_name,
+                                                        image_72=slack_user.image_72,
+                                                        is_bot=str(slack_user.is_bot).lower(),
+                                                        is_admin=str(slack_user.is_admin).lower(),
+                                                        slack_team_id=slack_team.id, user_id=user.id)
         response = client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_invalid_team(self, auth_client, user_factory, slack_team_factory, slack_user_factory):
+    def test_invalid_team(self, auth_client, mutation_generator, user_factory, slack_team_factory, slack_user_factory):
         user = user_factory()
         slack_team = slack_team_factory.build()
         slack_user = slack_user_factory.build()
 
-        mutation = f'''
-          mutation {{
-            createSlackUser(input: {{id: "{slack_user.id}", name: "{slack_user.name}",
-                                     realName: "{slack_user.real_name}", displayName: "{slack_user.display_name}",
-                                     image72: "{slack_user.image_72}", isBot: {str(slack_user.is_bot).lower()},
-                                     isAdmin: {str(slack_user.is_admin).lower()}, slackTeamId: "{slack_team.id}",
-                                     userId: {user.id}}}) {{
-              slackUser {{
-                id
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_slack_user(id=slack_user.id, name=slack_user.name,
+                                                        real_name=slack_user.real_name,
+                                                        display_name=slack_user.display_name,
+                                                        image_72=slack_user.image_72,
+                                                        is_bot=str(slack_user.is_bot).lower(),
+                                                        is_admin=str(slack_user.is_admin).lower(),
+                                                        slack_team_id=slack_team.id, user_id=user.id)
         response = auth_client.post('/graphql', {'query': mutation})
-        print(response.content)
 
         assert response.status_code == 200
         assert response.json()['errors'][0]['message'] == f"{{'slack_team_id': ['Invalid pk \"{slack_team.id}\" - " \
                                                           "object does not exist.']}"
 
     @pytest.mark.django_db
-    def test_invalid_user(self, auth_client, slack_team_factory, slack_user_factory):
+    def test_invalid_user(self, auth_client, mutation_generator, slack_team_factory, slack_user_factory):
         slack_team = slack_team_factory()
         slack_user = slack_user_factory.build()
 
-        mutation = f'''
-          mutation {{
-            createSlackUser(input: {{id: "{slack_user.id}", name: "{slack_user.name}",
-                                     realName: "{slack_user.real_name}", displayName: "{slack_user.display_name}",
-                                     image72: "{slack_user.image_72}", isBot: {str(slack_user.is_bot).lower()},
-                                     isAdmin: {str(slack_user.is_admin).lower()}, slackTeamId: "{slack_team.id}",
-                                     userId: 1}}) {{
-              slackUser {{
-                id
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_slack_user(id=slack_user.id, name=slack_user.name,
+                                                        real_name=slack_user.real_name,
+                                                        display_name=slack_user.display_name,
+                                                        image_72=slack_user.image_72,
+                                                        is_bot=str(slack_user.is_bot).lower(),
+                                                        is_admin=str(slack_user.is_admin).lower(),
+                                                        slack_team_id=slack_team.id, user_id=1)
         response = auth_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200
         assert response.json()['errors'][0]['message'] == "{'user_id': ['Invalid pk \"1\" - object does not exist.']}"
 
     @pytest.mark.django_db
-    def test_valid(self, auth_client, user_factory, slack_team_factory, slack_user_factory):
+    def test_valid(self, auth_client, mutation_generator, user_factory, slack_team_factory, slack_user_factory):
         user = user_factory()
         slack_team = slack_team_factory()
         slack_user = slack_user_factory.build()
 
-        mutation = f'''
-          mutation {{
-            createSlackUser(input: {{id: "{slack_user.id}", name: "{slack_user.name}",
-                                     realName: "{slack_user.real_name}", displayName: "{slack_user.display_name}",
-                                     image72: "{slack_user.image_72}", isBot: {str(slack_user.is_bot).lower()},
-                                     isAdmin: {str(slack_user.is_admin).lower()}, slackTeamId: "{slack_team.id}",
-                                     userId: {user.id}}}) {{
-              slackUser {{
-                id
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_slack_user(id=slack_user.id, name=slack_user.name,
+                                                        real_name=slack_user.real_name,
+                                                        display_name=slack_user.display_name,
+                                                        image_72=slack_user.image_72,
+                                                        is_bot=str(slack_user.is_bot).lower(),
+                                                        is_admin=str(slack_user.is_admin).lower(),
+                                                        slack_team_id=slack_team.id, user_id=user.id)
         response = auth_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200

--- a/tests/func/slack_integration/test_create_slack_user.py
+++ b/tests/func/slack_integration/test_create_slack_user.py
@@ -1,76 +1,78 @@
 import pytest
 
+from tests.resources.MutationGenerator import MutationGenerator
+
 
 class TestCreateSlackUser:
 
     @pytest.mark.django_db
-    def test_unauthenticated(self, client, mutation_generator, user_factory, slack_team_factory, slack_user_factory):
+    def test_unauthenticated(self, client, user_factory, slack_team_factory, slack_user_factory):
         user = user_factory()
         slack_team = slack_team_factory()
         slack_user = slack_user_factory.build()
 
-        mutation = mutation_generator.create_slack_user(id=slack_user.id, name=slack_user.name,
-                                                        real_name=slack_user.real_name,
-                                                        display_name=slack_user.display_name,
-                                                        image_72=slack_user.image_72,
-                                                        is_bot=str(slack_user.is_bot).lower(),
-                                                        is_admin=str(slack_user.is_admin).lower(),
-                                                        slack_team_id=slack_team.id, user_id=user.id)
+        mutation = MutationGenerator.create_slack_user(id=slack_user.id, name=slack_user.name,
+                                                       real_name=slack_user.real_name,
+                                                       display_name=slack_user.display_name,
+                                                       image_72=slack_user.image_72,
+                                                       is_bot=str(slack_user.is_bot).lower(),
+                                                       is_admin=str(slack_user.is_admin).lower(),
+                                                       slack_team_id=slack_team.id, user_id=user.id)
         response = client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_invalid_team(self, auth_client, mutation_generator, user_factory, slack_team_factory, slack_user_factory):
+    def test_invalid_team(self, auth_client, user_factory, slack_team_factory, slack_user_factory):
         user = user_factory()
         slack_team = slack_team_factory.build()
         slack_user = slack_user_factory.build()
 
-        mutation = mutation_generator.create_slack_user(id=slack_user.id, name=slack_user.name,
-                                                        real_name=slack_user.real_name,
-                                                        display_name=slack_user.display_name,
-                                                        image_72=slack_user.image_72,
-                                                        is_bot=str(slack_user.is_bot).lower(),
-                                                        is_admin=str(slack_user.is_admin).lower(),
-                                                        slack_team_id=slack_team.id, user_id=user.id)
+        mutation = MutationGenerator.create_slack_user(id=slack_user.id, name=slack_user.name,
+                                                       real_name=slack_user.real_name,
+                                                       display_name=slack_user.display_name,
+                                                       image_72=slack_user.image_72,
+                                                       is_bot=str(slack_user.is_bot).lower(),
+                                                       is_admin=str(slack_user.is_admin).lower(),
+                                                       slack_team_id=slack_team.id, user_id=user.id)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['errors'][0]['message'] == f"{{'slack_team_id': ['Invalid pk \"{slack_team.id}\" - " \
                                                           "object does not exist.']}"
 
     @pytest.mark.django_db
-    def test_invalid_user(self, auth_client, mutation_generator, slack_team_factory, slack_user_factory):
+    def test_invalid_user(self, auth_client, slack_team_factory, slack_user_factory):
         slack_team = slack_team_factory()
         slack_user = slack_user_factory.build()
 
-        mutation = mutation_generator.create_slack_user(id=slack_user.id, name=slack_user.name,
-                                                        real_name=slack_user.real_name,
-                                                        display_name=slack_user.display_name,
-                                                        image_72=slack_user.image_72,
-                                                        is_bot=str(slack_user.is_bot).lower(),
-                                                        is_admin=str(slack_user.is_admin).lower(),
-                                                        slack_team_id=slack_team.id, user_id=1)
+        mutation = MutationGenerator.create_slack_user(id=slack_user.id, name=slack_user.name,
+                                                       real_name=slack_user.real_name,
+                                                       display_name=slack_user.display_name,
+                                                       image_72=slack_user.image_72,
+                                                       is_bot=str(slack_user.is_bot).lower(),
+                                                       is_admin=str(slack_user.is_admin).lower(),
+                                                       slack_team_id=slack_team.id, user_id=1)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['errors'][0]['message'] == "{'user_id': ['Invalid pk \"1\" - object does not exist.']}"
 
     @pytest.mark.django_db
-    def test_valid(self, auth_client, mutation_generator, user_factory, slack_team_factory, slack_user_factory):
+    def test_valid(self, auth_client, user_factory, slack_team_factory, slack_user_factory):
         user = user_factory()
         slack_team = slack_team_factory()
         slack_user = slack_user_factory.build()
 
-        mutation = mutation_generator.create_slack_user(id=slack_user.id, name=slack_user.name,
-                                                        real_name=slack_user.real_name,
-                                                        display_name=slack_user.display_name,
-                                                        image_72=slack_user.image_72,
-                                                        is_bot=str(slack_user.is_bot).lower(),
-                                                        is_admin=str(slack_user.is_admin).lower(),
-                                                        slack_team_id=slack_team.id, user_id=user.id)
+        mutation = MutationGenerator.create_slack_user(id=slack_user.id, name=slack_user.name,
+                                                       real_name=slack_user.real_name,
+                                                       display_name=slack_user.display_name,
+                                                       image_72=slack_user.image_72,
+                                                       is_bot=str(slack_user.is_bot).lower(),
+                                                       is_admin=str(slack_user.is_admin).lower(),
+                                                       slack_team_id=slack_team.id, user_id=user.id)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createSlackUser']['slackUser']['id'] == slack_user.id

--- a/tests/func/slack_integration/test_create_topic_from_slack.py
+++ b/tests/func/slack_integration/test_create_topic_from_slack.py
@@ -4,31 +4,16 @@ import pytest
 class TestCreateTopicFromSlack:
 
     @pytest.mark.django_db
-    def test_unauthenticated(self, client, topic_factory, slack_user_factory, tag_factory):
+    def test_unauthenticated(self, client, mutation_generator, topic_factory, slack_user_factory, tag_factory):
         slack_user = slack_user_factory()
         tag_one = tag_factory()
         tag_two = tag_factory.build()
         topic = topic_factory.build(is_private=False)
 
-        mutation = f'''
-          mutation {{
-            createTopicFromSlack(input: {{title: "{topic.title}",
-                                          description: "{topic.description}",
-                                          isPrivate: {str(topic.is_private).lower()},
-                                          originalPosterSlackUserId: "{slack_user.id}",
-                                          tags: [
-                                            {{name: "{tag_one.name}"}},
-                                            {{name: "{tag_two.name}"}}
-                                          ]}}) {{
-              topic {{
-                title
-                tags {{
-                  name
-                }}
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_topic_from_slack(title=topic.title, description=topic.description,
+                                                              is_private=str(topic.is_private).lower(),
+                                                              original_poster_slack_user_id=slack_user.id,
+                                                              tags=[tag_one, tag_two])
         response = client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200
@@ -36,31 +21,17 @@ class TestCreateTopicFromSlack:
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_invalid_original_poster_slack_user(self, auth_client, topic_factory, slack_user_factory, tag_factory):
+    def test_invalid_original_poster_slack_user(self, auth_client, mutation_generator, topic_factory,
+                                                slack_user_factory, tag_factory):
         slack_user = slack_user_factory.build()
         tag_one = tag_factory()
         tag_two = tag_factory.build()
         topic = topic_factory.build(is_private=False)
 
-        mutation = f'''
-          mutation {{
-            createTopicFromSlack(input: {{title: "{topic.title}",
-                                          description: "{topic.description}",
-                                          isPrivate: {str(topic.is_private).lower()},
-                                          originalPosterSlackUserId: "{slack_user.id}",
-                                          tags: [
-                                            {{name: "{tag_one.name}"}},
-                                            {{name: "{tag_two.name}"}}
-                                          ]}}) {{
-              topic {{
-                title
-                tags {{
-                  name
-                }}
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_topic_from_slack(title=topic.title, description=topic.description,
+                                                              is_private=str(topic.is_private).lower(),
+                                                              original_poster_slack_user_id=slack_user.id,
+                                                              tags=[tag_one, tag_two])
         response = auth_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200
@@ -68,33 +39,17 @@ class TestCreateTopicFromSlack:
         assert response.json()['errors'][0]['message'] == 'SlackUser matching query does not exist.'
 
     @pytest.mark.django_db
-    def test_valid(self, auth_client, topic_factory, slack_user_factory, tag_factory):
+    def test_valid(self, auth_client, mutation_generator, topic_factory, slack_user_factory, tag_factory):
         slack_user = slack_user_factory()
         tag_one = tag_factory()
         tag_two = tag_factory.build()
         topic = topic_factory.build(is_private=False)
 
-        mutation = f'''
-          mutation {{
-            createTopicFromSlack(input: {{title: "{topic.title}",
-                                          description: "{topic.description}",
-                                          isPrivate: {str(topic.is_private).lower()},
-                                          originalPosterSlackUserId: "{slack_user.id}",
-                                          tags: [
-                                            {{name: "{tag_one.name}"}},
-                                            {{name: "{tag_two.name}"}}
-                                          ]}}) {{
-              topic {{
-                title
-                tags {{
-                  name
-                }}
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_topic_from_slack(title=topic.title, description=topic.description,
+                                                              is_private=str(topic.is_private).lower(),
+                                                              original_poster_slack_user_id=slack_user.id,
+                                                              tags=[tag_one, tag_two])
         response = auth_client.post('/graphql', {'query': mutation})
-        print(response.content)
 
         assert response.status_code == 200
         assert len(response.json()['data']['createTopicFromSlack']['topic']['tags']) == 2

--- a/tests/func/slack_integration/test_create_topic_from_slack.py
+++ b/tests/func/slack_integration/test_create_topic_from_slack.py
@@ -1,56 +1,58 @@
 import pytest
 
+from tests.resources.MutationGenerator import MutationGenerator
+
 
 class TestCreateTopicFromSlack:
 
     @pytest.mark.django_db
-    def test_unauthenticated(self, client, mutation_generator, topic_factory, slack_user_factory, tag_factory):
+    def test_unauthenticated(self, client, topic_factory, slack_user_factory, tag_factory):
         slack_user = slack_user_factory()
         tag_one = tag_factory()
         tag_two = tag_factory.build()
         topic = topic_factory.build(is_private=False)
 
-        mutation = mutation_generator.create_topic_from_slack(title=topic.title, description=topic.description,
-                                                              is_private=str(topic.is_private).lower(),
-                                                              original_poster_slack_user_id=slack_user.id,
-                                                              tags=[tag_one, tag_two])
+        mutation = MutationGenerator.create_topic_from_slack(title=topic.title, description=topic.description,
+                                                             is_private=str(topic.is_private).lower(),
+                                                             original_poster_slack_user_id=slack_user.id,
+                                                             tags=[tag_one, tag_two])
         response = client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createTopicFromSlack'] is None
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_invalid_original_poster_slack_user(self, auth_client, mutation_generator, topic_factory,
+    def test_invalid_original_poster_slack_user(self, auth_client, topic_factory,
                                                 slack_user_factory, tag_factory):
         slack_user = slack_user_factory.build()
         tag_one = tag_factory()
         tag_two = tag_factory.build()
         topic = topic_factory.build(is_private=False)
 
-        mutation = mutation_generator.create_topic_from_slack(title=topic.title, description=topic.description,
-                                                              is_private=str(topic.is_private).lower(),
-                                                              original_poster_slack_user_id=slack_user.id,
-                                                              tags=[tag_one, tag_two])
+        mutation = MutationGenerator.create_topic_from_slack(title=topic.title, description=topic.description,
+                                                             is_private=str(topic.is_private).lower(),
+                                                             original_poster_slack_user_id=slack_user.id,
+                                                             tags=[tag_one, tag_two])
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createTopicFromSlack'] is None
         assert response.json()['errors'][0]['message'] == 'SlackUser matching query does not exist.'
 
     @pytest.mark.django_db
-    def test_valid(self, auth_client, mutation_generator, topic_factory, slack_user_factory, tag_factory):
+    def test_valid(self, auth_client, topic_factory, slack_user_factory, tag_factory):
         slack_user = slack_user_factory()
         tag_one = tag_factory()
         tag_two = tag_factory.build()
         topic = topic_factory.build(is_private=False)
 
-        mutation = mutation_generator.create_topic_from_slack(title=topic.title, description=topic.description,
-                                                              is_private=str(topic.is_private).lower(),
-                                                              original_poster_slack_user_id=slack_user.id,
-                                                              tags=[tag_one, tag_two])
+        mutation = MutationGenerator.create_topic_from_slack(title=topic.title, description=topic.description,
+                                                             is_private=str(topic.is_private).lower(),
+                                                             original_poster_slack_user_id=slack_user.id,
+                                                             tags=[tag_one, tag_two])
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert len(response.json()['data']['createTopicFromSlack']['topic']['tags']) == 2
         assert response.json()['data']['createTopicFromSlack']['topic']['title'] == topic.title

--- a/tests/func/slack_integration/test_create_user_and_message_from_slack.py
+++ b/tests/func/slack_integration/test_create_user_and_message_from_slack.py
@@ -1,10 +1,12 @@
 import pytest
 
+from tests.resources.MutationGenerator import MutationGenerator
+
 
 class TestCreateUserAndMessageFromSlack:
 
     @pytest.mark.django_db
-    def test_unauthenticated(self, client, mutation_generator, message_factory, slack_event_factory, slack_user_factory,
+    def test_unauthenticated(self, client, message_factory, slack_event_factory, slack_user_factory,
                              slack_channel_factory, slack_team_factory):
         slack_team = slack_team_factory()
         slack_event = slack_event_factory.build()
@@ -12,27 +14,27 @@ class TestCreateUserAndMessageFromSlack:
         message = message_factory.build()
         slack_channel = slack_channel_factory(discussion__topic__is_private=False)
 
-        mutation = mutation_generator.create_user_and_message_from_slack(id=slack_user.id, name=slack_user.name,
-                                                                         first_name=slack_user.first_name,
-                                                                         last_name=slack_user.last_name,
-                                                                         real_name=slack_user.real_name,
-                                                                         display_name=slack_user.display_name,
-                                                                         email=slack_user.email,
-                                                                         image_72=slack_user.image_72,
-                                                                         is_bot=str(slack_user.is_bot).lower(),
-                                                                         is_admin=str(slack_user.is_admin).lower(),
-                                                                         slack_team_id=slack_user.slack_team_id,
-                                                                         origin_slack_event_ts=slack_event.ts,
-                                                                         slack_channel_id=slack_channel.id,
-                                                                         text=message.text)
+        mutation = MutationGenerator.create_user_and_message_from_slack(id=slack_user.id, name=slack_user.name,
+                                                                        first_name=slack_user.first_name,
+                                                                        last_name=slack_user.last_name,
+                                                                        real_name=slack_user.real_name,
+                                                                        display_name=slack_user.display_name,
+                                                                        email=slack_user.email,
+                                                                        image_72=slack_user.image_72,
+                                                                        is_bot=str(slack_user.is_bot).lower(),
+                                                                        is_admin=str(slack_user.is_admin).lower(),
+                                                                        slack_team_id=slack_user.slack_team_id,
+                                                                        origin_slack_event_ts=slack_event.ts,
+                                                                        slack_channel_id=slack_channel.id,
+                                                                        text=message.text)
         response = client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createUserAndMessageFromSlack'] is None
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_invalid_slack_user(self, auth_client, mutation_generator, message_factory, slack_event_factory,
+    def test_invalid_slack_user(self, auth_client, message_factory, slack_event_factory,
                                 slack_user_factory, slack_channel_factory, slack_team_factory):
         slack_team = slack_team_factory()
         slack_event = slack_event_factory.build()
@@ -40,56 +42,56 @@ class TestCreateUserAndMessageFromSlack:
         message = message_factory.build()
         slack_channel = slack_channel_factory(discussion__topic__is_private=False)
 
-        mutation = mutation_generator.create_user_and_message_from_slack(id=slack_user.id, name=slack_user.name,
-                                                                         first_name=slack_user.first_name,
-                                                                         last_name=slack_user.last_name,
-                                                                         real_name=slack_user.real_name,
-                                                                         display_name=slack_user.display_name,
-                                                                         email=slack_user.email,
-                                                                         image_72=slack_user.image_72,
-                                                                         is_bot=str(slack_user.is_bot).lower(),
-                                                                         is_admin=str(slack_user.is_admin).lower(),
-                                                                         slack_team_id=slack_user.slack_team_id,
-                                                                         origin_slack_event_ts=slack_event.ts,
-                                                                         slack_channel_id=slack_channel.id,
-                                                                         text=message.text)
+        mutation = MutationGenerator.create_user_and_message_from_slack(id=slack_user.id, name=slack_user.name,
+                                                                        first_name=slack_user.first_name,
+                                                                        last_name=slack_user.last_name,
+                                                                        real_name=slack_user.real_name,
+                                                                        display_name=slack_user.display_name,
+                                                                        email=slack_user.email,
+                                                                        image_72=slack_user.image_72,
+                                                                        is_bot=str(slack_user.is_bot).lower(),
+                                                                        is_admin=str(slack_user.is_admin).lower(),
+                                                                        slack_team_id=slack_user.slack_team_id,
+                                                                        origin_slack_event_ts=slack_event.ts,
+                                                                        slack_channel_id=slack_channel.id,
+                                                                        text=message.text)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createUserAndMessageFromSlack'] is None
         assert response.json()['errors'][0]['message'] == "{'id': ['slack user with this id already exists.']}"
 
     @pytest.mark.django_db
-    def test_invalid_slack_team(self, auth_client, mutation_generator, message_factory, slack_event_factory,
+    def test_invalid_slack_team(self, auth_client, message_factory, slack_event_factory,
                                 slack_user_factory, slack_channel_factory):
         slack_event = slack_event_factory.build()
         slack_user = slack_user_factory.build()
         message = message_factory.build()
         slack_channel = slack_channel_factory(discussion__topic__is_private=False)
 
-        mutation = mutation_generator.create_user_and_message_from_slack(id=slack_user.id, name=slack_user.name,
-                                                                         first_name=slack_user.first_name,
-                                                                         last_name=slack_user.last_name,
-                                                                         real_name=slack_user.real_name,
-                                                                         display_name=slack_user.display_name,
-                                                                         email=slack_user.email,
-                                                                         image_72=slack_user.image_72,
-                                                                         is_bot=str(slack_user.is_bot).lower(),
-                                                                         is_admin=str(slack_user.is_admin).lower(),
-                                                                         slack_team_id=slack_user.slack_team_id,
-                                                                         origin_slack_event_ts=slack_event.ts,
-                                                                         slack_channel_id=slack_channel.id,
-                                                                         text=message.text)
+        mutation = MutationGenerator.create_user_and_message_from_slack(id=slack_user.id, name=slack_user.name,
+                                                                        first_name=slack_user.first_name,
+                                                                        last_name=slack_user.last_name,
+                                                                        real_name=slack_user.real_name,
+                                                                        display_name=slack_user.display_name,
+                                                                        email=slack_user.email,
+                                                                        image_72=slack_user.image_72,
+                                                                        is_bot=str(slack_user.is_bot).lower(),
+                                                                        is_admin=str(slack_user.is_admin).lower(),
+                                                                        slack_team_id=slack_user.slack_team_id,
+                                                                        origin_slack_event_ts=slack_event.ts,
+                                                                        slack_channel_id=slack_channel.id,
+                                                                        text=message.text)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createUserAndMessageFromSlack'] is None
         assert response.json()['errors'][0]['message'] == f"{{'slack_team_id': ['Invalid pk " \
                                                           f"\"{slack_user.slack_team_id}\" - " \
                                                           "object does not exist.']}"
 
     @pytest.mark.django_db
-    def test_invalid_slack_channel(self, auth_client, mutation_generator, message_factory, slack_event_factory,
+    def test_invalid_slack_channel(self, auth_client, message_factory, slack_event_factory,
                                    slack_user_factory, slack_channel_factory, slack_team_factory):
         slack_team = slack_team_factory()
         slack_event = slack_event_factory.build()
@@ -97,27 +99,27 @@ class TestCreateUserAndMessageFromSlack:
         message = message_factory.build()
         slack_channel = slack_channel_factory.build()
 
-        mutation = mutation_generator.create_user_and_message_from_slack(id=slack_user.id, name=slack_user.name,
-                                                                         first_name=slack_user.first_name,
-                                                                         last_name=slack_user.last_name,
-                                                                         real_name=slack_user.real_name,
-                                                                         display_name=slack_user.display_name,
-                                                                         email=slack_user.email,
-                                                                         image_72=slack_user.image_72,
-                                                                         is_bot=str(slack_user.is_bot).lower(),
-                                                                         is_admin=str(slack_user.is_admin).lower(),
-                                                                         slack_team_id=slack_user.slack_team_id,
-                                                                         origin_slack_event_ts=slack_event.ts,
-                                                                         slack_channel_id=slack_channel.id,
-                                                                         text=message.text)
+        mutation = MutationGenerator.create_user_and_message_from_slack(id=slack_user.id, name=slack_user.name,
+                                                                        first_name=slack_user.first_name,
+                                                                        last_name=slack_user.last_name,
+                                                                        real_name=slack_user.real_name,
+                                                                        display_name=slack_user.display_name,
+                                                                        email=slack_user.email,
+                                                                        image_72=slack_user.image_72,
+                                                                        is_bot=str(slack_user.is_bot).lower(),
+                                                                        is_admin=str(slack_user.is_admin).lower(),
+                                                                        slack_team_id=slack_user.slack_team_id,
+                                                                        origin_slack_event_ts=slack_event.ts,
+                                                                        slack_channel_id=slack_channel.id,
+                                                                        text=message.text)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createUserAndMessageFromSlack'] is None
         assert response.json()['errors'][0]['message'] == 'Discussion matching query does not exist.'
 
     @pytest.mark.django_db
-    def test_valid(self, auth_client, mutation_generator, message_factory, slack_event_factory, slack_user_factory,
+    def test_valid(self, auth_client, message_factory, slack_event_factory, slack_user_factory,
                    slack_channel_factory, slack_team_factory):
         slack_team = slack_team_factory()
         slack_event = slack_event_factory.build()
@@ -125,20 +127,20 @@ class TestCreateUserAndMessageFromSlack:
         message = message_factory.build()
         slack_channel = slack_channel_factory(discussion__topic__is_private=False)
 
-        mutation = mutation_generator.create_user_and_message_from_slack(id=slack_user.id, name=slack_user.name,
-                                                                         first_name=slack_user.first_name,
-                                                                         last_name=slack_user.last_name,
-                                                                         real_name=slack_user.real_name,
-                                                                         display_name=slack_user.display_name,
-                                                                         email=slack_user.email,
-                                                                         image_72=slack_user.image_72,
-                                                                         is_bot=str(slack_user.is_bot).lower(),
-                                                                         is_admin=str(slack_user.is_admin).lower(),
-                                                                         slack_team_id=slack_user.slack_team_id,
-                                                                         origin_slack_event_ts=slack_event.ts,
-                                                                         slack_channel_id=slack_channel.id,
-                                                                         text=message.text)
+        mutation = MutationGenerator.create_user_and_message_from_slack(id=slack_user.id, name=slack_user.name,
+                                                                        first_name=slack_user.first_name,
+                                                                        last_name=slack_user.last_name,
+                                                                        real_name=slack_user.real_name,
+                                                                        display_name=slack_user.display_name,
+                                                                        email=slack_user.email,
+                                                                        image_72=slack_user.image_72,
+                                                                        is_bot=str(slack_user.is_bot).lower(),
+                                                                        is_admin=str(slack_user.is_admin).lower(),
+                                                                        slack_team_id=slack_user.slack_team_id,
+                                                                        origin_slack_event_ts=slack_event.ts,
+                                                                        slack_channel_id=slack_channel.id,
+                                                                        text=message.text)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createUserAndMessageFromSlack']['slackUser']['user']['alias']

--- a/tests/func/slack_integration/test_create_user_and_message_from_slack.py
+++ b/tests/func/slack_integration/test_create_user_and_message_from_slack.py
@@ -4,7 +4,7 @@ import pytest
 class TestCreateUserAndMessageFromSlack:
 
     @pytest.mark.django_db
-    def test_unauthenticated(self, client, message_factory, slack_event_factory, slack_user_factory,
+    def test_unauthenticated(self, client, mutation_generator, message_factory, slack_event_factory, slack_user_factory,
                              slack_channel_factory, slack_team_factory):
         slack_team = slack_team_factory()
         slack_event = slack_event_factory.build()
@@ -12,30 +12,19 @@ class TestCreateUserAndMessageFromSlack:
         message = message_factory.build()
         slack_channel = slack_channel_factory(discussion__topic__is_private=False)
 
-        mutation = f'''
-          mutation {{
-            createUserAndMessageFromSlack(input: {{slackUser: {{id: "{slack_user.id}",
-                                                                name: "{slack_user.name}",
-                                                                firstName: "{slack_user.first_name}",
-                                                                lastName: "{slack_user.last_name}",
-                                                                realName: "{slack_user.real_name}",
-                                                                displayName: "{slack_user.display_name}",
-                                                                email: "{slack_user.email}",
-                                                                image72: "{slack_user.image_72}",
-                                                                isBot: {str(slack_user.is_bot).lower()},
-                                                                isAdmin: {str(slack_user.is_admin).lower()},
-                                                                slackTeamId: "{slack_user.slack_team_id}"}},
-                                                    originSlackEventTs: "{slack_event.ts}",
-                                                    slackChannelId: "{slack_channel.id}",
-                                                    text: "{message.text}"}}) {{
-              slackUser {{
-                user {{
-                  alias
-                }}
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_user_and_message_from_slack(id=slack_user.id, name=slack_user.name,
+                                                                         first_name=slack_user.first_name,
+                                                                         last_name=slack_user.last_name,
+                                                                         real_name=slack_user.real_name,
+                                                                         display_name=slack_user.display_name,
+                                                                         email=slack_user.email,
+                                                                         image_72=slack_user.image_72,
+                                                                         is_bot=str(slack_user.is_bot).lower(),
+                                                                         is_admin=str(slack_user.is_admin).lower(),
+                                                                         slack_team_id=slack_user.slack_team_id,
+                                                                         origin_slack_event_ts=slack_event.ts,
+                                                                         slack_channel_id=slack_channel.id,
+                                                                         text=message.text)
         response = client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200
@@ -43,38 +32,27 @@ class TestCreateUserAndMessageFromSlack:
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_invalid_slack_user(self, auth_client, message_factory, slack_event_factory, slack_user_factory,
-                                slack_channel_factory, slack_team_factory):
+    def test_invalid_slack_user(self, auth_client, mutation_generator, message_factory, slack_event_factory,
+                                slack_user_factory, slack_channel_factory, slack_team_factory):
         slack_team = slack_team_factory()
         slack_event = slack_event_factory.build()
         slack_user = slack_user_factory(slack_team=slack_team)
         message = message_factory.build()
         slack_channel = slack_channel_factory(discussion__topic__is_private=False)
 
-        mutation = f'''
-          mutation {{
-            createUserAndMessageFromSlack(input: {{slackUser: {{id: "{slack_user.id}",
-                                                                name: "{slack_user.name}",
-                                                                firstName: "{slack_user.first_name}",
-                                                                lastName: "{slack_user.last_name}",
-                                                                realName: "{slack_user.real_name}",
-                                                                displayName: "{slack_user.display_name}",
-                                                                email: "{slack_user.email}",
-                                                                image72: "{slack_user.image_72}",
-                                                                isBot: {str(slack_user.is_bot).lower()},
-                                                                isAdmin: {str(slack_user.is_admin).lower()},
-                                                                slackTeamId: "{slack_user.slack_team_id}"}},
-                                                    originSlackEventTs: "{slack_event.ts}",
-                                                    slackChannelId: "{slack_channel.id}",
-                                                    text: "{message.text}"}}) {{
-              slackUser {{
-                user {{
-                  alias
-                }}
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_user_and_message_from_slack(id=slack_user.id, name=slack_user.name,
+                                                                         first_name=slack_user.first_name,
+                                                                         last_name=slack_user.last_name,
+                                                                         real_name=slack_user.real_name,
+                                                                         display_name=slack_user.display_name,
+                                                                         email=slack_user.email,
+                                                                         image_72=slack_user.image_72,
+                                                                         is_bot=str(slack_user.is_bot).lower(),
+                                                                         is_admin=str(slack_user.is_admin).lower(),
+                                                                         slack_team_id=slack_user.slack_team_id,
+                                                                         origin_slack_event_ts=slack_event.ts,
+                                                                         slack_channel_id=slack_channel.id,
+                                                                         text=message.text)
         response = auth_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200
@@ -82,37 +60,26 @@ class TestCreateUserAndMessageFromSlack:
         assert response.json()['errors'][0]['message'] == "{'id': ['slack user with this id already exists.']}"
 
     @pytest.mark.django_db
-    def test_invalid_slack_team(self, auth_client, message_factory, slack_event_factory, slack_user_factory,
-                                slack_channel_factory):
+    def test_invalid_slack_team(self, auth_client, mutation_generator, message_factory, slack_event_factory,
+                                slack_user_factory, slack_channel_factory):
         slack_event = slack_event_factory.build()
         slack_user = slack_user_factory.build()
         message = message_factory.build()
         slack_channel = slack_channel_factory(discussion__topic__is_private=False)
 
-        mutation = f'''
-          mutation {{
-            createUserAndMessageFromSlack(input: {{slackUser: {{id: "{slack_user.id}",
-                                                                name: "{slack_user.name}",
-                                                                firstName: "{slack_user.first_name}",
-                                                                lastName: "{slack_user.last_name}",
-                                                                realName: "{slack_user.real_name}",
-                                                                displayName: "{slack_user.display_name}",
-                                                                email: "{slack_user.email}",
-                                                                image72: "{slack_user.image_72}",
-                                                                isBot: {str(slack_user.is_bot).lower()},
-                                                                isAdmin: {str(slack_user.is_admin).lower()},
-                                                                slackTeamId: "{slack_user.slack_team_id}"}},
-                                                    originSlackEventTs: "{slack_event.ts}",
-                                                    slackChannelId: "{slack_channel.id}",
-                                                    text: "{message.text}"}}) {{
-              slackUser {{
-                user {{
-                  alias
-                }}
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_user_and_message_from_slack(id=slack_user.id, name=slack_user.name,
+                                                                         first_name=slack_user.first_name,
+                                                                         last_name=slack_user.last_name,
+                                                                         real_name=slack_user.real_name,
+                                                                         display_name=slack_user.display_name,
+                                                                         email=slack_user.email,
+                                                                         image_72=slack_user.image_72,
+                                                                         is_bot=str(slack_user.is_bot).lower(),
+                                                                         is_admin=str(slack_user.is_admin).lower(),
+                                                                         slack_team_id=slack_user.slack_team_id,
+                                                                         origin_slack_event_ts=slack_event.ts,
+                                                                         slack_channel_id=slack_channel.id,
+                                                                         text=message.text)
         response = auth_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200
@@ -122,38 +89,27 @@ class TestCreateUserAndMessageFromSlack:
                                                           "object does not exist.']}"
 
     @pytest.mark.django_db
-    def test_invalid_slack_channel(self, auth_client, message_factory, slack_event_factory, slack_user_factory,
-                                   slack_channel_factory, slack_team_factory):
+    def test_invalid_slack_channel(self, auth_client, mutation_generator, message_factory, slack_event_factory,
+                                   slack_user_factory, slack_channel_factory, slack_team_factory):
         slack_team = slack_team_factory()
         slack_event = slack_event_factory.build()
         slack_user = slack_user_factory.build(slack_team=slack_team)
         message = message_factory.build()
         slack_channel = slack_channel_factory.build()
 
-        mutation = f'''
-          mutation {{
-            createUserAndMessageFromSlack(input: {{slackUser: {{id: "{slack_user.id}",
-                                                                name: "{slack_user.name}",
-                                                                firstName: "{slack_user.first_name}",
-                                                                lastName: "{slack_user.last_name}",
-                                                                realName: "{slack_user.real_name}",
-                                                                displayName: "{slack_user.display_name}",
-                                                                email: "{slack_user.email}",
-                                                                image72: "{slack_user.image_72}",
-                                                                isBot: {str(slack_user.is_bot).lower()},
-                                                                isAdmin: {str(slack_user.is_admin).lower()},
-                                                                slackTeamId: "{slack_user.slack_team_id}"}},
-                                                    originSlackEventTs: "{slack_event.ts}",
-                                                    slackChannelId: "{slack_channel.id}",
-                                                    text: "{message.text}"}}) {{
-              slackUser {{
-                user {{
-                  alias
-                }}
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_user_and_message_from_slack(id=slack_user.id, name=slack_user.name,
+                                                                         first_name=slack_user.first_name,
+                                                                         last_name=slack_user.last_name,
+                                                                         real_name=slack_user.real_name,
+                                                                         display_name=slack_user.display_name,
+                                                                         email=slack_user.email,
+                                                                         image_72=slack_user.image_72,
+                                                                         is_bot=str(slack_user.is_bot).lower(),
+                                                                         is_admin=str(slack_user.is_admin).lower(),
+                                                                         slack_team_id=slack_user.slack_team_id,
+                                                                         origin_slack_event_ts=slack_event.ts,
+                                                                         slack_channel_id=slack_channel.id,
+                                                                         text=message.text)
         response = auth_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200
@@ -161,7 +117,7 @@ class TestCreateUserAndMessageFromSlack:
         assert response.json()['errors'][0]['message'] == 'Discussion matching query does not exist.'
 
     @pytest.mark.django_db
-    def test_valid(self, auth_client, message_factory, slack_event_factory, slack_user_factory,
+    def test_valid(self, auth_client, mutation_generator, message_factory, slack_event_factory, slack_user_factory,
                    slack_channel_factory, slack_team_factory):
         slack_team = slack_team_factory()
         slack_event = slack_event_factory.build()
@@ -169,30 +125,19 @@ class TestCreateUserAndMessageFromSlack:
         message = message_factory.build()
         slack_channel = slack_channel_factory(discussion__topic__is_private=False)
 
-        mutation = f'''
-          mutation {{
-            createUserAndMessageFromSlack(input: {{slackUser: {{id: "{slack_user.id}",
-                                                                name: "{slack_user.name}",
-                                                                firstName: "{slack_user.first_name}",
-                                                                lastName: "{slack_user.last_name}",
-                                                                realName: "{slack_user.real_name}",
-                                                                displayName: "{slack_user.display_name}",
-                                                                email: "{slack_user.email}",
-                                                                image72: "{slack_user.image_72}",
-                                                                isBot: {str(slack_user.is_bot).lower()},
-                                                                isAdmin: {str(slack_user.is_admin).lower()},
-                                                                slackTeamId: "{slack_user.slack_team_id}"}},
-                                                    originSlackEventTs: "{slack_event.ts}",
-                                                    slackChannelId: "{slack_channel.id}",
-                                                    text: "{message.text}"}}) {{
-              slackUser {{
-                user {{
-                  alias
-                }}
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_user_and_message_from_slack(id=slack_user.id, name=slack_user.name,
+                                                                         first_name=slack_user.first_name,
+                                                                         last_name=slack_user.last_name,
+                                                                         real_name=slack_user.real_name,
+                                                                         display_name=slack_user.display_name,
+                                                                         email=slack_user.email,
+                                                                         image_72=slack_user.image_72,
+                                                                         is_bot=str(slack_user.is_bot).lower(),
+                                                                         is_admin=str(slack_user.is_admin).lower(),
+                                                                         slack_team_id=slack_user.slack_team_id,
+                                                                         origin_slack_event_ts=slack_event.ts,
+                                                                         slack_channel_id=slack_channel.id,
+                                                                         text=message.text)
         response = auth_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200

--- a/tests/func/slack_integration/test_create_user_and_reply_from_slack.py
+++ b/tests/func/slack_integration/test_create_user_and_reply_from_slack.py
@@ -4,49 +4,31 @@ import pytest
 class TestCreateUserAndReplyFromSlack:
 
     @pytest.mark.django_db
-    def test_unauthenticated(self, client, message_factory, reply_factory, slack_event_factory,
+    def test_unauthenticated(self, client, mutation_generator, message_factory, reply_factory, slack_event_factory,
                              slack_channel_factory, slack_user_factory, slack_team_factory):
         slack_channel = slack_channel_factory(discussion__topic__is_private=False)
         message = message_factory(discussion=slack_channel.discussion)
-        message_slack_event = slack_event_factory(message=message)
+        message_event = slack_event_factory(message=message)
         slack_team = slack_team_factory()
         slack_user = slack_user_factory.build(slack_team=slack_team)
-        reply_slack_event = slack_event_factory.build()
+        reply_event = slack_event_factory.build()
         reply = reply_factory.build(message=message)
 
-        mutation = f'''
-          mutation {{
-            createUserAndReplyFromSlack(input: {{slackUser: {{
-                                                   id: "{slack_user.id}",
-                                                   name: "{slack_user.name}",
-                                                   firstName: "{slack_user.first_name}",
-                                                   lastName: "{slack_user.last_name}",
-                                                   realName: "{slack_user.real_name}",
-                                                   displayName: "{slack_user.display_name}",
-                                                   email: "{slack_user.email}",
-                                                   image72: "{slack_user.image_72}",
-                                                   isBot: {str(slack_user.is_bot).lower()},
-                                                   isAdmin: {str(slack_user.is_admin).lower()},
-                                                   slackTeamId: "{slack_user.slack_team.id}"
-                                                 }},
-                                                 messageOriginSlackEventTs: "{message_slack_event.ts}",
-                                                 originSlackEventTs: "{reply_slack_event.ts}",
-                                                 slackChannelId: "{slack_channel.id}",
-                                                 text: "{reply.text}"}}) {{
-              slackUser {{
-                id
-              }}
-              user {{
-                alias
-              }}
-              reply {{
-                message {{
-                  id
-                }}
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_user_and_reply_from_slack(id=slack_user.id,
+                                                                       name=slack_user.name,
+                                                                       first_name=slack_user.first_name,
+                                                                       last_name=slack_user.last_name,
+                                                                       real_name=slack_user.real_name,
+                                                                       display_name=slack_user.display_name,
+                                                                       email=slack_user.email,
+                                                                       image_72=slack_user.image_72,
+                                                                       is_bot=str(slack_user.is_bot).lower(),
+                                                                       is_admin=str(slack_user.is_admin).lower(),
+                                                                       slack_team_id=slack_user.slack_team.id,
+                                                                       message_origin_slack_event_ts=message_event.ts,
+                                                                       origin_slack_event_ts=reply_event.ts,
+                                                                       slack_channel_id=slack_channel.id,
+                                                                       text=reply.text)
         response = client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200
@@ -54,49 +36,31 @@ class TestCreateUserAndReplyFromSlack:
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_invalid_slack_user(self, auth_client, message_factory, reply_factory, slack_event_factory,
-                                slack_channel_factory, slack_user_factory, slack_team_factory):
+    def test_invalid_slack_user(self, auth_client, mutation_generator, message_factory, reply_factory,
+                                slack_event_factory, slack_channel_factory, slack_user_factory, slack_team_factory):
         slack_channel = slack_channel_factory(discussion__topic__is_private=False)
         message = message_factory(discussion=slack_channel.discussion)
-        message_slack_event = slack_event_factory(message=message)
+        message_event = slack_event_factory(message=message)
         slack_team = slack_team_factory()
         slack_user = slack_user_factory(slack_team=slack_team)
-        reply_slack_event = slack_event_factory.build()
+        reply_event = slack_event_factory.build()
         reply = reply_factory.build(message=message)
 
-        mutation = f'''
-          mutation {{
-            createUserAndReplyFromSlack(input: {{slackUser: {{
-                                                   id: "{slack_user.id}",
-                                                   name: "{slack_user.name}",
-                                                   firstName: "{slack_user.first_name}",
-                                                   lastName: "{slack_user.last_name}",
-                                                   realName: "{slack_user.real_name}",
-                                                   displayName: "{slack_user.display_name}",
-                                                   email: "{slack_user.email}",
-                                                   image72: "{slack_user.image_72}",
-                                                   isBot: {str(slack_user.is_bot).lower()},
-                                                   isAdmin: {str(slack_user.is_admin).lower()},
-                                                   slackTeamId: "{slack_user.slack_team.id}"
-                                                 }},
-                                                 messageOriginSlackEventTs: "{message_slack_event.ts}",
-                                                 originSlackEventTs: "{reply_slack_event.ts}",
-                                                 slackChannelId: "{slack_channel.id}",
-                                                 text: "{reply.text}"}}) {{
-              slackUser {{
-                id
-              }}
-              user {{
-                alias
-              }}
-              reply {{
-                message {{
-                  id
-                }}
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_user_and_reply_from_slack(id=slack_user.id,
+                                                                       name=slack_user.name,
+                                                                       first_name=slack_user.first_name,
+                                                                       last_name=slack_user.last_name,
+                                                                       real_name=slack_user.real_name,
+                                                                       display_name=slack_user.display_name,
+                                                                       email=slack_user.email,
+                                                                       image_72=slack_user.image_72,
+                                                                       is_bot=str(slack_user.is_bot).lower(),
+                                                                       is_admin=str(slack_user.is_admin).lower(),
+                                                                       slack_team_id=slack_user.slack_team.id,
+                                                                       message_origin_slack_event_ts=message_event.ts,
+                                                                       origin_slack_event_ts=reply_event.ts,
+                                                                       slack_channel_id=slack_channel.id,
+                                                                       text=reply.text)
         response = auth_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200
@@ -104,49 +68,31 @@ class TestCreateUserAndReplyFromSlack:
         assert response.json()['errors'][0]['message'] == "{'id': ['slack user with this id already exists.']}"
 
     @pytest.mark.django_db
-    def test_invalid_slack_team(self, auth_client, message_factory, reply_factory, slack_event_factory,
-                                slack_channel_factory, slack_user_factory, slack_team_factory):
+    def test_invalid_slack_team(self, auth_client, mutation_generator, message_factory, reply_factory,
+                                slack_event_factory, slack_channel_factory, slack_user_factory, slack_team_factory):
         slack_channel = slack_channel_factory(discussion__topic__is_private=False)
         message = message_factory(discussion=slack_channel.discussion)
-        message_slack_event = slack_event_factory(message=message)
+        message_event = slack_event_factory(message=message)
         slack_team = slack_team_factory.build()
         slack_user = slack_user_factory.build(slack_team=slack_team)
-        reply_slack_event = slack_event_factory.build()
+        reply_event = slack_event_factory.build()
         reply = reply_factory.build(message=message)
 
-        mutation = f'''
-          mutation {{
-            createUserAndReplyFromSlack(input: {{slackUser: {{
-                                                   id: "{slack_user.id}",
-                                                   name: "{slack_user.name}",
-                                                   firstName: "{slack_user.first_name}",
-                                                   lastName: "{slack_user.last_name}",
-                                                   realName: "{slack_user.real_name}",
-                                                   displayName: "{slack_user.display_name}",
-                                                   email: "{slack_user.email}",
-                                                   image72: "{slack_user.image_72}",
-                                                   isBot: {str(slack_user.is_bot).lower()},
-                                                   isAdmin: {str(slack_user.is_admin).lower()},
-                                                   slackTeamId: "{slack_user.slack_team.id}"
-                                                 }},
-                                                 messageOriginSlackEventTs: "{message_slack_event.ts}",
-                                                 originSlackEventTs: "{reply_slack_event.ts}",
-                                                 slackChannelId: "{slack_channel.id}",
-                                                 text: "{reply.text}"}}) {{
-              slackUser {{
-                id
-              }}
-              user {{
-                alias
-              }}
-              reply {{
-                message {{
-                  id
-                }}
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_user_and_reply_from_slack(id=slack_user.id,
+                                                                       name=slack_user.name,
+                                                                       first_name=slack_user.first_name,
+                                                                       last_name=slack_user.last_name,
+                                                                       real_name=slack_user.real_name,
+                                                                       display_name=slack_user.display_name,
+                                                                       email=slack_user.email,
+                                                                       image_72=slack_user.image_72,
+                                                                       is_bot=str(slack_user.is_bot).lower(),
+                                                                       is_admin=str(slack_user.is_admin).lower(),
+                                                                       slack_team_id=slack_user.slack_team.id,
+                                                                       message_origin_slack_event_ts=message_event.ts,
+                                                                       origin_slack_event_ts=reply_event.ts,
+                                                                       slack_channel_id=slack_channel.id,
+                                                                       text=reply.text)
         response = auth_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200
@@ -155,49 +101,31 @@ class TestCreateUserAndReplyFromSlack:
                                                           "object does not exist.']}"
 
     @pytest.mark.django_db
-    def test_invalid_slack_channel(self, auth_client, message_factory, reply_factory, slack_event_factory,
-                                   slack_channel_factory, slack_user_factory, slack_team_factory):
+    def test_invalid_slack_channel(self, auth_client, mutation_generator, message_factory, reply_factory,
+                                   slack_event_factory, slack_channel_factory, slack_user_factory, slack_team_factory):
         slack_channel = slack_channel_factory.build()
         message = message_factory()
-        message_slack_event = slack_event_factory(message=message)
+        message_event = slack_event_factory(message=message)
         slack_team = slack_team_factory()
         slack_user = slack_user_factory.build(slack_team=slack_team)
-        reply_slack_event = slack_event_factory.build()
+        reply_event = slack_event_factory.build()
         reply = reply_factory.build(message=message)
 
-        mutation = f'''
-          mutation {{
-            createUserAndReplyFromSlack(input: {{slackUser: {{
-                                                   id: "{slack_user.id}",
-                                                   name: "{slack_user.name}",
-                                                   firstName: "{slack_user.first_name}",
-                                                   lastName: "{slack_user.last_name}",
-                                                   realName: "{slack_user.real_name}",
-                                                   displayName: "{slack_user.display_name}",
-                                                   email: "{slack_user.email}",
-                                                   image72: "{slack_user.image_72}",
-                                                   isBot: {str(slack_user.is_bot).lower()},
-                                                   isAdmin: {str(slack_user.is_admin).lower()},
-                                                   slackTeamId: "{slack_user.slack_team.id}"
-                                                 }},
-                                                 messageOriginSlackEventTs: "{message_slack_event.ts}",
-                                                 originSlackEventTs: "{reply_slack_event.ts}",
-                                                 slackChannelId: "{slack_channel.id}",
-                                                 text: "{reply.text}"}}) {{
-              slackUser {{
-                id
-              }}
-              user {{
-                alias
-              }}
-              reply {{
-                message {{
-                  id
-                }}
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_user_and_reply_from_slack(id=slack_user.id,
+                                                                       name=slack_user.name,
+                                                                       first_name=slack_user.first_name,
+                                                                       last_name=slack_user.last_name,
+                                                                       real_name=slack_user.real_name,
+                                                                       display_name=slack_user.display_name,
+                                                                       email=slack_user.email,
+                                                                       image_72=slack_user.image_72,
+                                                                       is_bot=str(slack_user.is_bot).lower(),
+                                                                       is_admin=str(slack_user.is_admin).lower(),
+                                                                       slack_team_id=slack_user.slack_team.id,
+                                                                       message_origin_slack_event_ts=message_event.ts,
+                                                                       origin_slack_event_ts=reply_event.ts,
+                                                                       slack_channel_id=slack_channel.id,
+                                                                       text=reply.text)
         response = auth_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200
@@ -205,49 +133,31 @@ class TestCreateUserAndReplyFromSlack:
         assert response.json()['errors'][0]['message'] == 'Message matching query does not exist.'
 
     @pytest.mark.django_db
-    def test_invalid_message(self, auth_client, message_factory, reply_factory, slack_event_factory,
+    def test_invalid_message(self, auth_client, mutation_generator, message_factory, reply_factory, slack_event_factory,
                              slack_channel_factory, slack_user_factory, slack_team_factory):
         slack_channel = slack_channel_factory(discussion__topic__is_private=False)
         message = message_factory.build(discussion=slack_channel.discussion)
-        message_slack_event = slack_event_factory.build()
+        message_event = slack_event_factory.build()
         slack_team = slack_team_factory()
         slack_user = slack_user_factory.build(slack_team=slack_team)
-        reply_slack_event = slack_event_factory.build()
+        reply_event = slack_event_factory.build()
         reply = reply_factory.build(message=message)
 
-        mutation = f'''
-          mutation {{
-            createUserAndReplyFromSlack(input: {{slackUser: {{
-                                                   id: "{slack_user.id}",
-                                                   name: "{slack_user.name}",
-                                                   firstName: "{slack_user.first_name}",
-                                                   lastName: "{slack_user.last_name}",
-                                                   realName: "{slack_user.real_name}",
-                                                   displayName: "{slack_user.display_name}",
-                                                   email: "{slack_user.email}",
-                                                   image72: "{slack_user.image_72}",
-                                                   isBot: {str(slack_user.is_bot).lower()},
-                                                   isAdmin: {str(slack_user.is_admin).lower()},
-                                                   slackTeamId: "{slack_user.slack_team.id}"
-                                                 }},
-                                                 messageOriginSlackEventTs: "{message_slack_event.ts}",
-                                                 originSlackEventTs: "{reply_slack_event.ts}",
-                                                 slackChannelId: "{slack_channel.id}",
-                                                 text: "{reply.text}"}}) {{
-              slackUser {{
-                id
-              }}
-              user {{
-                alias
-              }}
-              reply {{
-                message {{
-                  id
-                }}
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_user_and_reply_from_slack(id=slack_user.id,
+                                                                       name=slack_user.name,
+                                                                       first_name=slack_user.first_name,
+                                                                       last_name=slack_user.last_name,
+                                                                       real_name=slack_user.real_name,
+                                                                       display_name=slack_user.display_name,
+                                                                       email=slack_user.email,
+                                                                       image_72=slack_user.image_72,
+                                                                       is_bot=str(slack_user.is_bot).lower(),
+                                                                       is_admin=str(slack_user.is_admin).lower(),
+                                                                       slack_team_id=slack_user.slack_team.id,
+                                                                       message_origin_slack_event_ts=message_event.ts,
+                                                                       origin_slack_event_ts=reply_event.ts,
+                                                                       slack_channel_id=slack_channel.id,
+                                                                       text=reply.text)
         response = auth_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200
@@ -255,49 +165,31 @@ class TestCreateUserAndReplyFromSlack:
         assert response.json()['errors'][0]['message'] == 'Message matching query does not exist.'
 
     @pytest.mark.django_db
-    def test_valid(self, auth_client, message_factory, reply_factory, slack_event_factory,
+    def test_valid(self, auth_client, mutation_generator, message_factory, reply_factory, slack_event_factory,
                    slack_channel_factory, slack_user_factory, slack_team_factory):
         slack_channel = slack_channel_factory(discussion__topic__is_private=False)
         message = message_factory(discussion=slack_channel.discussion)
-        message_slack_event = slack_event_factory(message=message)
+        message_event = slack_event_factory(message=message)
         slack_team = slack_team_factory()
         slack_user = slack_user_factory.build(slack_team=slack_team)
-        reply_slack_event = slack_event_factory.build()
+        reply_event = slack_event_factory.build()
         reply = reply_factory.build(message=message)
 
-        mutation = f'''
-          mutation {{
-            createUserAndReplyFromSlack(input: {{slackUser: {{
-                                                   id: "{slack_user.id}",
-                                                   name: "{slack_user.name}",
-                                                   firstName: "{slack_user.first_name}",
-                                                   lastName: "{slack_user.last_name}",
-                                                   realName: "{slack_user.real_name}",
-                                                   displayName: "{slack_user.display_name}",
-                                                   email: "{slack_user.email}",
-                                                   image72: "{slack_user.image_72}",
-                                                   isBot: {str(slack_user.is_bot).lower()},
-                                                   isAdmin: {str(slack_user.is_admin).lower()},
-                                                   slackTeamId: "{slack_user.slack_team.id}"
-                                                 }},
-                                                 messageOriginSlackEventTs: "{message_slack_event.ts}",
-                                                 originSlackEventTs: "{reply_slack_event.ts}",
-                                                 slackChannelId: "{slack_channel.id}",
-                                                 text: "{reply.text}"}}) {{
-              slackUser {{
-                id
-              }}
-              user {{
-                alias
-              }}
-              reply {{
-                message {{
-                  id
-                }}
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_user_and_reply_from_slack(id=slack_user.id,
+                                                                       name=slack_user.name,
+                                                                       first_name=slack_user.first_name,
+                                                                       last_name=slack_user.last_name,
+                                                                       real_name=slack_user.real_name,
+                                                                       display_name=slack_user.display_name,
+                                                                       email=slack_user.email,
+                                                                       image_72=slack_user.image_72,
+                                                                       is_bot=str(slack_user.is_bot).lower(),
+                                                                       is_admin=str(slack_user.is_admin).lower(),
+                                                                       slack_team_id=slack_user.slack_team.id,
+                                                                       message_origin_slack_event_ts=message_event.ts,
+                                                                       origin_slack_event_ts=reply_event.ts,
+                                                                       slack_channel_id=slack_channel.id,
+                                                                       text=reply.text)
         response = auth_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200

--- a/tests/func/slack_integration/test_create_user_and_reply_from_slack.py
+++ b/tests/func/slack_integration/test_create_user_and_reply_from_slack.py
@@ -1,10 +1,12 @@
 import pytest
 
+from tests.resources.MutationGenerator import MutationGenerator
+
 
 class TestCreateUserAndReplyFromSlack:
 
     @pytest.mark.django_db
-    def test_unauthenticated(self, client, mutation_generator, message_factory, reply_factory, slack_event_factory,
+    def test_unauthenticated(self, client, message_factory, reply_factory, slack_event_factory,
                              slack_channel_factory, slack_user_factory, slack_team_factory):
         slack_channel = slack_channel_factory(discussion__topic__is_private=False)
         message = message_factory(discussion=slack_channel.discussion)
@@ -14,29 +16,29 @@ class TestCreateUserAndReplyFromSlack:
         reply_event = slack_event_factory.build()
         reply = reply_factory.build(message=message)
 
-        mutation = mutation_generator.create_user_and_reply_from_slack(id=slack_user.id,
-                                                                       name=slack_user.name,
-                                                                       first_name=slack_user.first_name,
-                                                                       last_name=slack_user.last_name,
-                                                                       real_name=slack_user.real_name,
-                                                                       display_name=slack_user.display_name,
-                                                                       email=slack_user.email,
-                                                                       image_72=slack_user.image_72,
-                                                                       is_bot=str(slack_user.is_bot).lower(),
-                                                                       is_admin=str(slack_user.is_admin).lower(),
-                                                                       slack_team_id=slack_user.slack_team.id,
-                                                                       message_origin_slack_event_ts=message_event.ts,
-                                                                       origin_slack_event_ts=reply_event.ts,
-                                                                       slack_channel_id=slack_channel.id,
-                                                                       text=reply.text)
+        mutation = MutationGenerator.create_user_and_reply_from_slack(id=slack_user.id,
+                                                                      name=slack_user.name,
+                                                                      first_name=slack_user.first_name,
+                                                                      last_name=slack_user.last_name,
+                                                                      real_name=slack_user.real_name,
+                                                                      display_name=slack_user.display_name,
+                                                                      email=slack_user.email,
+                                                                      image_72=slack_user.image_72,
+                                                                      is_bot=str(slack_user.is_bot).lower(),
+                                                                      is_admin=str(slack_user.is_admin).lower(),
+                                                                      slack_team_id=slack_user.slack_team.id,
+                                                                      message_origin_slack_event_ts=message_event.ts,
+                                                                      origin_slack_event_ts=reply_event.ts,
+                                                                      slack_channel_id=slack_channel.id,
+                                                                      text=reply.text)
         response = client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createUserAndReplyFromSlack'] is None
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_invalid_slack_user(self, auth_client, mutation_generator, message_factory, reply_factory,
+    def test_invalid_slack_user(self, auth_client, message_factory, reply_factory,
                                 slack_event_factory, slack_channel_factory, slack_user_factory, slack_team_factory):
         slack_channel = slack_channel_factory(discussion__topic__is_private=False)
         message = message_factory(discussion=slack_channel.discussion)
@@ -46,29 +48,29 @@ class TestCreateUserAndReplyFromSlack:
         reply_event = slack_event_factory.build()
         reply = reply_factory.build(message=message)
 
-        mutation = mutation_generator.create_user_and_reply_from_slack(id=slack_user.id,
-                                                                       name=slack_user.name,
-                                                                       first_name=slack_user.first_name,
-                                                                       last_name=slack_user.last_name,
-                                                                       real_name=slack_user.real_name,
-                                                                       display_name=slack_user.display_name,
-                                                                       email=slack_user.email,
-                                                                       image_72=slack_user.image_72,
-                                                                       is_bot=str(slack_user.is_bot).lower(),
-                                                                       is_admin=str(slack_user.is_admin).lower(),
-                                                                       slack_team_id=slack_user.slack_team.id,
-                                                                       message_origin_slack_event_ts=message_event.ts,
-                                                                       origin_slack_event_ts=reply_event.ts,
-                                                                       slack_channel_id=slack_channel.id,
-                                                                       text=reply.text)
+        mutation = MutationGenerator.create_user_and_reply_from_slack(id=slack_user.id,
+                                                                      name=slack_user.name,
+                                                                      first_name=slack_user.first_name,
+                                                                      last_name=slack_user.last_name,
+                                                                      real_name=slack_user.real_name,
+                                                                      display_name=slack_user.display_name,
+                                                                      email=slack_user.email,
+                                                                      image_72=slack_user.image_72,
+                                                                      is_bot=str(slack_user.is_bot).lower(),
+                                                                      is_admin=str(slack_user.is_admin).lower(),
+                                                                      slack_team_id=slack_user.slack_team.id,
+                                                                      message_origin_slack_event_ts=message_event.ts,
+                                                                      origin_slack_event_ts=reply_event.ts,
+                                                                      slack_channel_id=slack_channel.id,
+                                                                      text=reply.text)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createUserAndReplyFromSlack'] is None
         assert response.json()['errors'][0]['message'] == "{'id': ['slack user with this id already exists.']}"
 
     @pytest.mark.django_db
-    def test_invalid_slack_team(self, auth_client, mutation_generator, message_factory, reply_factory,
+    def test_invalid_slack_team(self, auth_client, message_factory, reply_factory,
                                 slack_event_factory, slack_channel_factory, slack_user_factory, slack_team_factory):
         slack_channel = slack_channel_factory(discussion__topic__is_private=False)
         message = message_factory(discussion=slack_channel.discussion)
@@ -78,30 +80,30 @@ class TestCreateUserAndReplyFromSlack:
         reply_event = slack_event_factory.build()
         reply = reply_factory.build(message=message)
 
-        mutation = mutation_generator.create_user_and_reply_from_slack(id=slack_user.id,
-                                                                       name=slack_user.name,
-                                                                       first_name=slack_user.first_name,
-                                                                       last_name=slack_user.last_name,
-                                                                       real_name=slack_user.real_name,
-                                                                       display_name=slack_user.display_name,
-                                                                       email=slack_user.email,
-                                                                       image_72=slack_user.image_72,
-                                                                       is_bot=str(slack_user.is_bot).lower(),
-                                                                       is_admin=str(slack_user.is_admin).lower(),
-                                                                       slack_team_id=slack_user.slack_team.id,
-                                                                       message_origin_slack_event_ts=message_event.ts,
-                                                                       origin_slack_event_ts=reply_event.ts,
-                                                                       slack_channel_id=slack_channel.id,
-                                                                       text=reply.text)
+        mutation = MutationGenerator.create_user_and_reply_from_slack(id=slack_user.id,
+                                                                      name=slack_user.name,
+                                                                      first_name=slack_user.first_name,
+                                                                      last_name=slack_user.last_name,
+                                                                      real_name=slack_user.real_name,
+                                                                      display_name=slack_user.display_name,
+                                                                      email=slack_user.email,
+                                                                      image_72=slack_user.image_72,
+                                                                      is_bot=str(slack_user.is_bot).lower(),
+                                                                      is_admin=str(slack_user.is_admin).lower(),
+                                                                      slack_team_id=slack_user.slack_team.id,
+                                                                      message_origin_slack_event_ts=message_event.ts,
+                                                                      origin_slack_event_ts=reply_event.ts,
+                                                                      slack_channel_id=slack_channel.id,
+                                                                      text=reply.text)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createUserAndReplyFromSlack'] is None
         assert response.json()['errors'][0]['message'] == f"{{'slack_team_id': ['Invalid pk \"{slack_team.id}\" - " \
                                                           "object does not exist.']}"
 
     @pytest.mark.django_db
-    def test_invalid_slack_channel(self, auth_client, mutation_generator, message_factory, reply_factory,
+    def test_invalid_slack_channel(self, auth_client, message_factory, reply_factory,
                                    slack_event_factory, slack_channel_factory, slack_user_factory, slack_team_factory):
         slack_channel = slack_channel_factory.build()
         message = message_factory()
@@ -111,29 +113,29 @@ class TestCreateUserAndReplyFromSlack:
         reply_event = slack_event_factory.build()
         reply = reply_factory.build(message=message)
 
-        mutation = mutation_generator.create_user_and_reply_from_slack(id=slack_user.id,
-                                                                       name=slack_user.name,
-                                                                       first_name=slack_user.first_name,
-                                                                       last_name=slack_user.last_name,
-                                                                       real_name=slack_user.real_name,
-                                                                       display_name=slack_user.display_name,
-                                                                       email=slack_user.email,
-                                                                       image_72=slack_user.image_72,
-                                                                       is_bot=str(slack_user.is_bot).lower(),
-                                                                       is_admin=str(slack_user.is_admin).lower(),
-                                                                       slack_team_id=slack_user.slack_team.id,
-                                                                       message_origin_slack_event_ts=message_event.ts,
-                                                                       origin_slack_event_ts=reply_event.ts,
-                                                                       slack_channel_id=slack_channel.id,
-                                                                       text=reply.text)
+        mutation = MutationGenerator.create_user_and_reply_from_slack(id=slack_user.id,
+                                                                      name=slack_user.name,
+                                                                      first_name=slack_user.first_name,
+                                                                      last_name=slack_user.last_name,
+                                                                      real_name=slack_user.real_name,
+                                                                      display_name=slack_user.display_name,
+                                                                      email=slack_user.email,
+                                                                      image_72=slack_user.image_72,
+                                                                      is_bot=str(slack_user.is_bot).lower(),
+                                                                      is_admin=str(slack_user.is_admin).lower(),
+                                                                      slack_team_id=slack_user.slack_team.id,
+                                                                      message_origin_slack_event_ts=message_event.ts,
+                                                                      origin_slack_event_ts=reply_event.ts,
+                                                                      slack_channel_id=slack_channel.id,
+                                                                      text=reply.text)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createUserAndReplyFromSlack'] is None
         assert response.json()['errors'][0]['message'] == 'Message matching query does not exist.'
 
     @pytest.mark.django_db
-    def test_invalid_message(self, auth_client, mutation_generator, message_factory, reply_factory, slack_event_factory,
+    def test_invalid_message(self, auth_client, message_factory, reply_factory, slack_event_factory,
                              slack_channel_factory, slack_user_factory, slack_team_factory):
         slack_channel = slack_channel_factory(discussion__topic__is_private=False)
         message = message_factory.build(discussion=slack_channel.discussion)
@@ -143,29 +145,29 @@ class TestCreateUserAndReplyFromSlack:
         reply_event = slack_event_factory.build()
         reply = reply_factory.build(message=message)
 
-        mutation = mutation_generator.create_user_and_reply_from_slack(id=slack_user.id,
-                                                                       name=slack_user.name,
-                                                                       first_name=slack_user.first_name,
-                                                                       last_name=slack_user.last_name,
-                                                                       real_name=slack_user.real_name,
-                                                                       display_name=slack_user.display_name,
-                                                                       email=slack_user.email,
-                                                                       image_72=slack_user.image_72,
-                                                                       is_bot=str(slack_user.is_bot).lower(),
-                                                                       is_admin=str(slack_user.is_admin).lower(),
-                                                                       slack_team_id=slack_user.slack_team.id,
-                                                                       message_origin_slack_event_ts=message_event.ts,
-                                                                       origin_slack_event_ts=reply_event.ts,
-                                                                       slack_channel_id=slack_channel.id,
-                                                                       text=reply.text)
+        mutation = MutationGenerator.create_user_and_reply_from_slack(id=slack_user.id,
+                                                                      name=slack_user.name,
+                                                                      first_name=slack_user.first_name,
+                                                                      last_name=slack_user.last_name,
+                                                                      real_name=slack_user.real_name,
+                                                                      display_name=slack_user.display_name,
+                                                                      email=slack_user.email,
+                                                                      image_72=slack_user.image_72,
+                                                                      is_bot=str(slack_user.is_bot).lower(),
+                                                                      is_admin=str(slack_user.is_admin).lower(),
+                                                                      slack_team_id=slack_user.slack_team.id,
+                                                                      message_origin_slack_event_ts=message_event.ts,
+                                                                      origin_slack_event_ts=reply_event.ts,
+                                                                      slack_channel_id=slack_channel.id,
+                                                                      text=reply.text)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createUserAndReplyFromSlack'] is None
         assert response.json()['errors'][0]['message'] == 'Message matching query does not exist.'
 
     @pytest.mark.django_db
-    def test_valid(self, auth_client, mutation_generator, message_factory, reply_factory, slack_event_factory,
+    def test_valid(self, auth_client, message_factory, reply_factory, slack_event_factory,
                    slack_channel_factory, slack_user_factory, slack_team_factory):
         slack_channel = slack_channel_factory(discussion__topic__is_private=False)
         message = message_factory(discussion=slack_channel.discussion)
@@ -175,24 +177,24 @@ class TestCreateUserAndReplyFromSlack:
         reply_event = slack_event_factory.build()
         reply = reply_factory.build(message=message)
 
-        mutation = mutation_generator.create_user_and_reply_from_slack(id=slack_user.id,
-                                                                       name=slack_user.name,
-                                                                       first_name=slack_user.first_name,
-                                                                       last_name=slack_user.last_name,
-                                                                       real_name=slack_user.real_name,
-                                                                       display_name=slack_user.display_name,
-                                                                       email=slack_user.email,
-                                                                       image_72=slack_user.image_72,
-                                                                       is_bot=str(slack_user.is_bot).lower(),
-                                                                       is_admin=str(slack_user.is_admin).lower(),
-                                                                       slack_team_id=slack_user.slack_team.id,
-                                                                       message_origin_slack_event_ts=message_event.ts,
-                                                                       origin_slack_event_ts=reply_event.ts,
-                                                                       slack_channel_id=slack_channel.id,
-                                                                       text=reply.text)
+        mutation = MutationGenerator.create_user_and_reply_from_slack(id=slack_user.id,
+                                                                      name=slack_user.name,
+                                                                      first_name=slack_user.first_name,
+                                                                      last_name=slack_user.last_name,
+                                                                      real_name=slack_user.real_name,
+                                                                      display_name=slack_user.display_name,
+                                                                      email=slack_user.email,
+                                                                      image_72=slack_user.image_72,
+                                                                      is_bot=str(slack_user.is_bot).lower(),
+                                                                      is_admin=str(slack_user.is_admin).lower(),
+                                                                      slack_team_id=slack_user.slack_team.id,
+                                                                      message_origin_slack_event_ts=message_event.ts,
+                                                                      origin_slack_event_ts=reply_event.ts,
+                                                                      slack_channel_id=slack_channel.id,
+                                                                      text=reply.text)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createUserAndReplyFromSlack']['slackUser']['id'] == slack_user.id
         assert response.json()['data']['createUserAndReplyFromSlack']['user']['alias']
         assert response.json()['data']['createUserAndReplyFromSlack']['reply']['message']['id'] == str(message.id)

--- a/tests/func/slack_integration/test_create_user_and_topic_from_slack.py
+++ b/tests/func/slack_integration/test_create_user_and_topic_from_slack.py
@@ -4,47 +4,29 @@ import pytest
 class TestCreateUserAndTopicFromSlack:
 
     @pytest.mark.django_db
-    def test_unauthenticated(self, client, topic_factory, slack_user_factory, slack_team_factory, tag_factory):
+    def test_unauthenticated(self, client, mutation_generator, topic_factory, slack_user_factory, slack_team_factory,
+                             tag_factory):
         slack_user = slack_user_factory.build()
         slack_team = slack_team_factory()
         tag_one = tag_factory()
         tag_two = tag_factory.build()
         topic = topic_factory.build(is_private=False)
 
-        mutation = f'''
-          mutation {{
-            createUserAndTopicFromSlack(input: {{title: "{topic.title}",
-                                                    description: "{topic.description}",
-                                                    isPrivate: {str(topic.is_private).lower()},
-                                                    originalPosterSlackUser: {{
-                                                      id: "{slack_user.id}",
-                                                      name: "{slack_user.name}",
-                                                      firstName: "{slack_user.first_name}",
-                                                      lastName: "{slack_user.last_name}",
-                                                      realName: "{slack_user.real_name}",
-                                                      displayName: "{slack_user.display_name}",
-                                                      email: "{slack_user.email}",
-                                                      image72: "{slack_user.image_72}",
-                                                      isBot: {str(slack_user.is_bot).lower()},
-                                                      isAdmin: {str(slack_user.is_admin).lower()},
-                                                      slackTeamId: "{slack_team.id}"
-                                                    }},
-                                                    tags: [
-                                                      {{name: "{tag_one.name}"}},
-                                                      {{name: "{tag_two.name}"}}
-                                                    ]}}) {{
-              topic {{
-                title
-                tags {{
-                  name
-                }}
-              }}
-              slackUser {{
-                id
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_user_and_topic_from_slack(title=topic.title,
+                                                                       description=topic.description,
+                                                                       is_private=str(topic.is_private).lower(),
+                                                                       id=slack_user.id,
+                                                                       name=slack_user.name,
+                                                                       first_name=slack_user.first_name,
+                                                                       last_name=slack_user.last_name,
+                                                                       real_name=slack_user.real_name,
+                                                                       display_name=slack_user.display_name,
+                                                                       email=slack_user.email,
+                                                                       image_72=slack_user.image_72,
+                                                                       is_bot=str(slack_user.is_bot).lower(),
+                                                                       is_admin=str(slack_user.is_admin).lower(),
+                                                                       slack_team_id=slack_team.id,
+                                                                       tags=[tag_one, tag_two])
         response = client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200
@@ -52,48 +34,29 @@ class TestCreateUserAndTopicFromSlack:
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_invalid_slack_user(self, auth_client, topic_factory, slack_user_factory, slack_team_factory,
-                                tag_factory):
+    def test_invalid_slack_user(self, auth_client, mutation_generator, topic_factory, slack_user_factory,
+                                slack_team_factory, tag_factory):
         slack_user = slack_user_factory()
         slack_team = slack_team_factory()
         tag_one = tag_factory()
         tag_two = tag_factory.build()
         topic = topic_factory.build(is_private=False)
 
-        mutation = f'''
-          mutation {{
-            createUserAndTopicFromSlack(input: {{title: "{topic.title}",
-                                                 description: "{topic.description}",
-                                                 isPrivate: {str(topic.is_private).lower()},
-                                                 originalPosterSlackUser: {{
-                                                   id: "{slack_user.id}",
-                                                   name: "{slack_user.name}",
-                                                   firstName: "{slack_user.first_name}",
-                                                   lastName: "{slack_user.last_name}",
-                                                   realName: "{slack_user.real_name}",
-                                                   displayName: "{slack_user.display_name}",
-                                                   email: "{slack_user.email}",
-                                                   image72: "{slack_user.image_72}",
-                                                   isBot: {str(slack_user.is_bot).lower()},
-                                                   isAdmin: {str(slack_user.is_admin).lower()},
-                                                   slackTeamId: "{slack_team.id}"
-                                                 }},
-                                                   tags: [
-                                                     {{name: "{tag_one.name}"}},
-                                                     {{name: "{tag_two.name}"}}
-                                                   ]}}) {{
-              topic {{
-                title
-                tags {{
-                  name
-                }}
-              }}
-              slackUser {{
-                id
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_user_and_topic_from_slack(title=topic.title,
+                                                                       description=topic.description,
+                                                                       is_private=str(topic.is_private).lower(),
+                                                                       id=slack_user.id,
+                                                                       name=slack_user.name,
+                                                                       first_name=slack_user.first_name,
+                                                                       last_name=slack_user.last_name,
+                                                                       real_name=slack_user.real_name,
+                                                                       display_name=slack_user.display_name,
+                                                                       email=slack_user.email,
+                                                                       image_72=slack_user.image_72,
+                                                                       is_bot=str(slack_user.is_bot).lower(),
+                                                                       is_admin=str(slack_user.is_admin).lower(),
+                                                                       slack_team_id=slack_team.id,
+                                                                       tags=[tag_one, tag_two])
         response = auth_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200
@@ -101,48 +64,29 @@ class TestCreateUserAndTopicFromSlack:
         assert response.json()['errors'][0]['message'] == "{'id': ['slack user with this id already exists.']}"
 
     @pytest.mark.django_db
-    def test_invalid_slack_team(self, auth_client, topic_factory, slack_user_factory, slack_team_factory,
-                                tag_factory):
+    def test_invalid_slack_team(self, auth_client, mutation_generator, topic_factory, slack_user_factory,
+                                slack_team_factory, tag_factory):
         slack_user = slack_user_factory.build()
         slack_team = slack_team_factory.build()
         tag_one = tag_factory()
         tag_two = tag_factory.build()
         topic = topic_factory.build(is_private=False)
 
-        mutation = f'''
-          mutation {{
-            createUserAndTopicFromSlack(input: {{title: "{topic.title}",
-                                                 description: "{topic.description}",
-                                                 isPrivate: {str(topic.is_private).lower()},
-                                                 originalPosterSlackUser: {{
-                                                   id: "{slack_user.id}",
-                                                   name: "{slack_user.name}",
-                                                   firstName: "{slack_user.first_name}",
-                                                   lastName: "{slack_user.last_name}",
-                                                   realName: "{slack_user.real_name}",
-                                                   displayName: "{slack_user.display_name}",
-                                                   email: "{slack_user.email}",
-                                                   image72: "{slack_user.image_72}",
-                                                   isBot: {str(slack_user.is_bot).lower()},
-                                                   isAdmin: {str(slack_user.is_admin).lower()},
-                                                   slackTeamId: "{slack_team.id}"
-                                                 }},
-                                                 tags: [
-                                                   {{name: "{tag_one.name}"}},
-                                                   {{name: "{tag_two.name}"}}
-                                                 ]}}) {{
-              topic {{
-                title
-                tags {{
-                  name
-                }}
-              }}
-              slackUser {{
-                id
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_user_and_topic_from_slack(title=topic.title,
+                                                                       description=topic.description,
+                                                                       is_private=str(topic.is_private).lower(),
+                                                                       id=slack_user.id,
+                                                                       name=slack_user.name,
+                                                                       first_name=slack_user.first_name,
+                                                                       last_name=slack_user.last_name,
+                                                                       real_name=slack_user.real_name,
+                                                                       display_name=slack_user.display_name,
+                                                                       email=slack_user.email,
+                                                                       image_72=slack_user.image_72,
+                                                                       is_bot=str(slack_user.is_bot).lower(),
+                                                                       is_admin=str(slack_user.is_admin).lower(),
+                                                                       slack_team_id=slack_team.id,
+                                                                       tags=[tag_one, tag_two])
         response = auth_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200
@@ -151,47 +95,29 @@ class TestCreateUserAndTopicFromSlack:
                                                           "object does not exist.']}"
 
     @pytest.mark.django_db
-    def test_valid(self, auth_client, topic_factory, slack_user_factory, slack_team_factory, tag_factory):
+    def test_valid(self, auth_client, mutation_generator, topic_factory, slack_user_factory, slack_team_factory,
+                   tag_factory):
         slack_user = slack_user_factory.build()
         slack_team = slack_team_factory()
         tag_one = tag_factory()
         tag_two = tag_factory.build()
         topic = topic_factory.build(is_private=False)
 
-        mutation = f'''
-          mutation {{
-            createUserAndTopicFromSlack(input: {{title: "{topic.title}",
-                                                 description: "{topic.description}",
-                                                 isPrivate: {str(topic.is_private).lower()},
-                                                 originalPosterSlackUser: {{
-                                                   id: "{slack_user.id}",
-                                                   name: "{slack_user.name}",
-                                                   firstName: "{slack_user.first_name}",
-                                                   lastName: "{slack_user.last_name}",
-                                                   realName: "{slack_user.real_name}",
-                                                   displayName: "{slack_user.display_name}",
-                                                   email: "{slack_user.email}",
-                                                   image72: "{slack_user.image_72}",
-                                                   isBot: {str(slack_user.is_bot).lower()},
-                                                   isAdmin: {str(slack_user.is_admin).lower()},
-                                                   slackTeamId: "{slack_team.id}"
-                                                 }},
-                                                 tags: [
-                                                   {{name: "{tag_one.name}"}},
-                                                   {{name: "{tag_two.name}"}}
-                                                 ]}}) {{
-              topic {{
-                title
-                tags {{
-                  name
-                }}
-              }}
-              slackUser {{
-                id
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_user_and_topic_from_slack(title=topic.title,
+                                                                       description=topic.description,
+                                                                       is_private=str(topic.is_private).lower(),
+                                                                       id=slack_user.id,
+                                                                       name=slack_user.name,
+                                                                       first_name=slack_user.first_name,
+                                                                       last_name=slack_user.last_name,
+                                                                       real_name=slack_user.real_name,
+                                                                       display_name=slack_user.display_name,
+                                                                       email=slack_user.email,
+                                                                       image_72=slack_user.image_72,
+                                                                       is_bot=str(slack_user.is_bot).lower(),
+                                                                       is_admin=str(slack_user.is_admin).lower(),
+                                                                       slack_team_id=slack_team.id,
+                                                                       tags=[tag_one, tag_two])
         response = auth_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200

--- a/tests/func/slack_integration/test_create_user_and_topic_from_slack.py
+++ b/tests/func/slack_integration/test_create_user_and_topic_from_slack.py
@@ -1,10 +1,12 @@
 import pytest
 
+from tests.resources.MutationGenerator import MutationGenerator
+
 
 class TestCreateUserAndTopicFromSlack:
 
     @pytest.mark.django_db
-    def test_unauthenticated(self, client, mutation_generator, topic_factory, slack_user_factory, slack_team_factory,
+    def test_unauthenticated(self, client, topic_factory, slack_user_factory, slack_team_factory,
                              tag_factory):
         slack_user = slack_user_factory.build()
         slack_team = slack_team_factory()
@@ -12,29 +14,29 @@ class TestCreateUserAndTopicFromSlack:
         tag_two = tag_factory.build()
         topic = topic_factory.build(is_private=False)
 
-        mutation = mutation_generator.create_user_and_topic_from_slack(title=topic.title,
-                                                                       description=topic.description,
-                                                                       is_private=str(topic.is_private).lower(),
-                                                                       id=slack_user.id,
-                                                                       name=slack_user.name,
-                                                                       first_name=slack_user.first_name,
-                                                                       last_name=slack_user.last_name,
-                                                                       real_name=slack_user.real_name,
-                                                                       display_name=slack_user.display_name,
-                                                                       email=slack_user.email,
-                                                                       image_72=slack_user.image_72,
-                                                                       is_bot=str(slack_user.is_bot).lower(),
-                                                                       is_admin=str(slack_user.is_admin).lower(),
-                                                                       slack_team_id=slack_team.id,
-                                                                       tags=[tag_one, tag_two])
+        mutation = MutationGenerator.create_user_and_topic_from_slack(title=topic.title,
+                                                                      description=topic.description,
+                                                                      is_private=str(topic.is_private).lower(),
+                                                                      id=slack_user.id,
+                                                                      name=slack_user.name,
+                                                                      first_name=slack_user.first_name,
+                                                                      last_name=slack_user.last_name,
+                                                                      real_name=slack_user.real_name,
+                                                                      display_name=slack_user.display_name,
+                                                                      email=slack_user.email,
+                                                                      image_72=slack_user.image_72,
+                                                                      is_bot=str(slack_user.is_bot).lower(),
+                                                                      is_admin=str(slack_user.is_admin).lower(),
+                                                                      slack_team_id=slack_team.id,
+                                                                      tags=[tag_one, tag_two])
         response = client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createUserAndTopicFromSlack'] is None
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_invalid_slack_user(self, auth_client, mutation_generator, topic_factory, slack_user_factory,
+    def test_invalid_slack_user(self, auth_client, topic_factory, slack_user_factory,
                                 slack_team_factory, tag_factory):
         slack_user = slack_user_factory()
         slack_team = slack_team_factory()
@@ -42,29 +44,29 @@ class TestCreateUserAndTopicFromSlack:
         tag_two = tag_factory.build()
         topic = topic_factory.build(is_private=False)
 
-        mutation = mutation_generator.create_user_and_topic_from_slack(title=topic.title,
-                                                                       description=topic.description,
-                                                                       is_private=str(topic.is_private).lower(),
-                                                                       id=slack_user.id,
-                                                                       name=slack_user.name,
-                                                                       first_name=slack_user.first_name,
-                                                                       last_name=slack_user.last_name,
-                                                                       real_name=slack_user.real_name,
-                                                                       display_name=slack_user.display_name,
-                                                                       email=slack_user.email,
-                                                                       image_72=slack_user.image_72,
-                                                                       is_bot=str(slack_user.is_bot).lower(),
-                                                                       is_admin=str(slack_user.is_admin).lower(),
-                                                                       slack_team_id=slack_team.id,
-                                                                       tags=[tag_one, tag_two])
+        mutation = MutationGenerator.create_user_and_topic_from_slack(title=topic.title,
+                                                                      description=topic.description,
+                                                                      is_private=str(topic.is_private).lower(),
+                                                                      id=slack_user.id,
+                                                                      name=slack_user.name,
+                                                                      first_name=slack_user.first_name,
+                                                                      last_name=slack_user.last_name,
+                                                                      real_name=slack_user.real_name,
+                                                                      display_name=slack_user.display_name,
+                                                                      email=slack_user.email,
+                                                                      image_72=slack_user.image_72,
+                                                                      is_bot=str(slack_user.is_bot).lower(),
+                                                                      is_admin=str(slack_user.is_admin).lower(),
+                                                                      slack_team_id=slack_team.id,
+                                                                      tags=[tag_one, tag_two])
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createUserAndTopicFromSlack'] is None
         assert response.json()['errors'][0]['message'] == "{'id': ['slack user with this id already exists.']}"
 
     @pytest.mark.django_db
-    def test_invalid_slack_team(self, auth_client, mutation_generator, topic_factory, slack_user_factory,
+    def test_invalid_slack_team(self, auth_client, topic_factory, slack_user_factory,
                                 slack_team_factory, tag_factory):
         slack_user = slack_user_factory.build()
         slack_team = slack_team_factory.build()
@@ -72,30 +74,30 @@ class TestCreateUserAndTopicFromSlack:
         tag_two = tag_factory.build()
         topic = topic_factory.build(is_private=False)
 
-        mutation = mutation_generator.create_user_and_topic_from_slack(title=topic.title,
-                                                                       description=topic.description,
-                                                                       is_private=str(topic.is_private).lower(),
-                                                                       id=slack_user.id,
-                                                                       name=slack_user.name,
-                                                                       first_name=slack_user.first_name,
-                                                                       last_name=slack_user.last_name,
-                                                                       real_name=slack_user.real_name,
-                                                                       display_name=slack_user.display_name,
-                                                                       email=slack_user.email,
-                                                                       image_72=slack_user.image_72,
-                                                                       is_bot=str(slack_user.is_bot).lower(),
-                                                                       is_admin=str(slack_user.is_admin).lower(),
-                                                                       slack_team_id=slack_team.id,
-                                                                       tags=[tag_one, tag_two])
+        mutation = MutationGenerator.create_user_and_topic_from_slack(title=topic.title,
+                                                                      description=topic.description,
+                                                                      is_private=str(topic.is_private).lower(),
+                                                                      id=slack_user.id,
+                                                                      name=slack_user.name,
+                                                                      first_name=slack_user.first_name,
+                                                                      last_name=slack_user.last_name,
+                                                                      real_name=slack_user.real_name,
+                                                                      display_name=slack_user.display_name,
+                                                                      email=slack_user.email,
+                                                                      image_72=slack_user.image_72,
+                                                                      is_bot=str(slack_user.is_bot).lower(),
+                                                                      is_admin=str(slack_user.is_admin).lower(),
+                                                                      slack_team_id=slack_team.id,
+                                                                      tags=[tag_one, tag_two])
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createUserAndTopicFromSlack'] is None
         assert response.json()['errors'][0]['message'] == f"{{'slack_team_id': ['Invalid pk \"{slack_team.id}\" - " \
                                                           "object does not exist.']}"
 
     @pytest.mark.django_db
-    def test_valid(self, auth_client, mutation_generator, topic_factory, slack_user_factory, slack_team_factory,
+    def test_valid(self, auth_client, topic_factory, slack_user_factory, slack_team_factory,
                    tag_factory):
         slack_user = slack_user_factory.build()
         slack_team = slack_team_factory()
@@ -103,24 +105,24 @@ class TestCreateUserAndTopicFromSlack:
         tag_two = tag_factory.build()
         topic = topic_factory.build(is_private=False)
 
-        mutation = mutation_generator.create_user_and_topic_from_slack(title=topic.title,
-                                                                       description=topic.description,
-                                                                       is_private=str(topic.is_private).lower(),
-                                                                       id=slack_user.id,
-                                                                       name=slack_user.name,
-                                                                       first_name=slack_user.first_name,
-                                                                       last_name=slack_user.last_name,
-                                                                       real_name=slack_user.real_name,
-                                                                       display_name=slack_user.display_name,
-                                                                       email=slack_user.email,
-                                                                       image_72=slack_user.image_72,
-                                                                       is_bot=str(slack_user.is_bot).lower(),
-                                                                       is_admin=str(slack_user.is_admin).lower(),
-                                                                       slack_team_id=slack_team.id,
-                                                                       tags=[tag_one, tag_two])
+        mutation = MutationGenerator.create_user_and_topic_from_slack(title=topic.title,
+                                                                      description=topic.description,
+                                                                      is_private=str(topic.is_private).lower(),
+                                                                      id=slack_user.id,
+                                                                      name=slack_user.name,
+                                                                      first_name=slack_user.first_name,
+                                                                      last_name=slack_user.last_name,
+                                                                      real_name=slack_user.real_name,
+                                                                      display_name=slack_user.display_name,
+                                                                      email=slack_user.email,
+                                                                      image_72=slack_user.image_72,
+                                                                      is_bot=str(slack_user.is_bot).lower(),
+                                                                      is_admin=str(slack_user.is_admin).lower(),
+                                                                      slack_team_id=slack_team.id,
+                                                                      tags=[tag_one, tag_two])
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createUserAndTopicFromSlack']['slackUser']['id'] == slack_user.id
         assert response.json()['data']['createUserAndTopicFromSlack']['topic']['title'] == topic.title
         assert len(response.json()['data']['createUserAndTopicFromSlack']['topic']['tags']) == 2

--- a/tests/func/slack_integration/test_create_user_from_slack.py
+++ b/tests/func/slack_integration/test_create_user_from_slack.py
@@ -4,31 +4,20 @@ import pytest
 class TestCreateUserFromSlack:
 
     @pytest.mark.django_db
-    def test_unauthenticated(self, client, slack_team_factory, slack_user_factory):
+    def test_unauthenticated(self, client, mutation_generator, slack_team_factory, slack_user_factory):
         slack_team = slack_team_factory()
         slack_user = slack_user_factory.build(slack_team=slack_team)
 
-        mutation = f'''
-          mutation {{
-            createUserFromSlack(input: {{id: "{slack_user.id}",
-                                         name: "{slack_user.name}",
-                                         firstName: "{slack_user.first_name}",
-                                         lastName: "{slack_user.last_name}",
-                                         realName: "{slack_user.real_name}",
-                                         displayName: "{slack_user.display_name}",
-                                         email: "{slack_user.email}",
-                                         image72: "{slack_user.image_72}",
-                                         isBot: {str(slack_user.is_bot).lower()},
-                                         isAdmin: {str(slack_user.is_admin).lower()},
-                                         slackTeamId: "{slack_team.id}"}}) {{
-              slackUser {{
-                user {{
-                  id
-                }}
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_user_from_slack(id=slack_user.id, name=slack_user.name,
+                                                             first_name=slack_user.first_name,
+                                                             last_name=slack_user.last_name,
+                                                             real_name=slack_user.real_name,
+                                                             display_name=slack_user.display_name,
+                                                             email=slack_user.email,
+                                                             image_72=slack_user.image_72,
+                                                             is_bot=str(slack_user.is_bot).lower(),
+                                                             is_admin=str(slack_user.is_admin).lower(),
+                                                             slack_team_id=slack_team.id)
         response = client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200
@@ -36,31 +25,20 @@ class TestCreateUserFromSlack:
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_invalid_existing_slack_user(self, auth_client, slack_team_factory, slack_user_factory):
+    def test_invalid_existing_slack_user(self, auth_client, mutation_generator, slack_team_factory, slack_user_factory):
         slack_team = slack_team_factory()
         slack_user = slack_user_factory(slack_team=slack_team)
 
-        mutation = f'''
-          mutation {{
-            createUserFromSlack(input: {{id: "{slack_user.id}",
-                                         name: "{slack_user.name}",
-                                         firstName: "{slack_user.first_name}",
-                                         lastName: "{slack_user.last_name}",
-                                         realName: "{slack_user.real_name}",
-                                         displayName: "{slack_user.display_name}",
-                                         email: "{slack_user.email}",
-                                         image72: "{slack_user.image_72}",
-                                         isBot: {str(slack_user.is_bot).lower()},
-                                         isAdmin: {str(slack_user.is_admin).lower()},
-                                         slackTeamId: "{slack_team.id}"}}) {{
-              slackUser {{
-                user {{
-                  id
-                }}
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_user_from_slack(id=slack_user.id, name=slack_user.name,
+                                                             first_name=slack_user.first_name,
+                                                             last_name=slack_user.last_name,
+                                                             real_name=slack_user.real_name,
+                                                             display_name=slack_user.display_name,
+                                                             email=slack_user.email,
+                                                             image_72=slack_user.image_72,
+                                                             is_bot=str(slack_user.is_bot).lower(),
+                                                             is_admin=str(slack_user.is_admin).lower(),
+                                                             slack_team_id=slack_team.id)
         response = auth_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200
@@ -68,64 +46,44 @@ class TestCreateUserFromSlack:
         assert response.json()['errors'][0]['message'] == "{'id': ['slack user with this id already exists.']}"
 
     @pytest.mark.django_db
-    def test_valid_and_gets_user(self, auth_client, slack_team_factory, user_factory, slack_user_factory):
+    def test_valid_and_gets_user(self, auth_client, mutation_generator, slack_team_factory, user_factory,
+                                 slack_user_factory):
         slack_team = slack_team_factory()
         user = user_factory()
         slack_user = slack_user_factory.build(slack_team=slack_team, email=user.email)
 
-        mutation = f'''
-          mutation {{
-            createUserFromSlack(input: {{id: "{slack_user.id}",
-                                         name: "{slack_user.name}",
-                                         firstName: "{slack_user.first_name}",
-                                         lastName: "{slack_user.last_name}",
-                                         realName: "{slack_user.real_name}",
-                                         displayName: "{slack_user.display_name}",
-                                         email: "{slack_user.email}",
-                                         image72: "{slack_user.image_72}",
-                                         isBot: {str(slack_user.is_bot).lower()},
-                                         isAdmin: {str(slack_user.is_admin).lower()},
-                                         slackTeamId: "{slack_team.id}"}}) {{
-              slackUser {{
-                user {{
-                  id
-                }}
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_user_from_slack(id=slack_user.id, name=slack_user.name,
+                                                             first_name=slack_user.first_name,
+                                                             last_name=slack_user.last_name,
+                                                             real_name=slack_user.real_name,
+                                                             display_name=slack_user.display_name,
+                                                             email=slack_user.email,
+                                                             image_72=slack_user.image_72,
+                                                             is_bot=str(slack_user.is_bot).lower(),
+                                                             is_admin=str(slack_user.is_admin).lower(),
+                                                             slack_team_id=slack_team.id)
         response = auth_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200
         assert response.json()['data']['createUserFromSlack']['slackUser']['user']['id'] == str(user.id)
 
     @pytest.mark.django_db
-    def test_valid_and_creates_user(self, auth_client, slack_team_factory, user_factory, slack_user_factory):
+    def test_valid_and_creates_user(self, auth_client, mutation_generator, slack_team_factory, user_factory,
+                                    slack_user_factory):
         slack_team = slack_team_factory()
         user = user_factory.build()
         slack_user = slack_user_factory.build(slack_team=slack_team, email=user.email)
 
-        mutation = f'''
-          mutation {{
-            createUserFromSlack(input: {{id: "{slack_user.id}",
-                                         name: "{slack_user.name}",
-                                         firstName: "{slack_user.first_name}",
-                                         lastName: "{slack_user.last_name}",
-                                         realName: "{slack_user.real_name}",
-                                         displayName: "{slack_user.display_name}",
-                                         email: "{slack_user.email}",
-                                         image72: "{slack_user.image_72}",
-                                         isBot: {str(slack_user.is_bot).lower()},
-                                         isAdmin: {str(slack_user.is_admin).lower()},
-                                         slackTeamId: "{slack_team.id}"}}) {{
-              slackUser {{
-                user {{
-                  alias
-                }}
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_user_from_slack(id=slack_user.id, name=slack_user.name,
+                                                             first_name=slack_user.first_name,
+                                                             last_name=slack_user.last_name,
+                                                             real_name=slack_user.real_name,
+                                                             display_name=slack_user.display_name,
+                                                             email=slack_user.email,
+                                                             image_72=slack_user.image_72,
+                                                             is_bot=str(slack_user.is_bot).lower(),
+                                                             is_admin=str(slack_user.is_admin).lower(),
+                                                             slack_team_id=slack_team.id)
         response = auth_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200

--- a/tests/func/slack_integration/test_create_user_from_slack.py
+++ b/tests/func/slack_integration/test_create_user_from_slack.py
@@ -1,90 +1,92 @@
 import pytest
 
+from tests.resources.MutationGenerator import MutationGenerator
+
 
 class TestCreateUserFromSlack:
 
     @pytest.mark.django_db
-    def test_unauthenticated(self, client, mutation_generator, slack_team_factory, slack_user_factory):
+    def test_unauthenticated(self, client, slack_team_factory, slack_user_factory):
         slack_team = slack_team_factory()
         slack_user = slack_user_factory.build(slack_team=slack_team)
 
-        mutation = mutation_generator.create_user_from_slack(id=slack_user.id, name=slack_user.name,
-                                                             first_name=slack_user.first_name,
-                                                             last_name=slack_user.last_name,
-                                                             real_name=slack_user.real_name,
-                                                             display_name=slack_user.display_name,
-                                                             email=slack_user.email,
-                                                             image_72=slack_user.image_72,
-                                                             is_bot=str(slack_user.is_bot).lower(),
-                                                             is_admin=str(slack_user.is_admin).lower(),
-                                                             slack_team_id=slack_team.id)
+        mutation = MutationGenerator.create_user_from_slack(id=slack_user.id, name=slack_user.name,
+                                                            first_name=slack_user.first_name,
+                                                            last_name=slack_user.last_name,
+                                                            real_name=slack_user.real_name,
+                                                            display_name=slack_user.display_name,
+                                                            email=slack_user.email,
+                                                            image_72=slack_user.image_72,
+                                                            is_bot=str(slack_user.is_bot).lower(),
+                                                            is_admin=str(slack_user.is_admin).lower(),
+                                                            slack_team_id=slack_team.id)
         response = client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createUserFromSlack'] is None
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_invalid_existing_slack_user(self, auth_client, mutation_generator, slack_team_factory, slack_user_factory):
+    def test_invalid_existing_slack_user(self, auth_client, slack_team_factory, slack_user_factory):
         slack_team = slack_team_factory()
         slack_user = slack_user_factory(slack_team=slack_team)
 
-        mutation = mutation_generator.create_user_from_slack(id=slack_user.id, name=slack_user.name,
-                                                             first_name=slack_user.first_name,
-                                                             last_name=slack_user.last_name,
-                                                             real_name=slack_user.real_name,
-                                                             display_name=slack_user.display_name,
-                                                             email=slack_user.email,
-                                                             image_72=slack_user.image_72,
-                                                             is_bot=str(slack_user.is_bot).lower(),
-                                                             is_admin=str(slack_user.is_admin).lower(),
-                                                             slack_team_id=slack_team.id)
+        mutation = MutationGenerator.create_user_from_slack(id=slack_user.id, name=slack_user.name,
+                                                            first_name=slack_user.first_name,
+                                                            last_name=slack_user.last_name,
+                                                            real_name=slack_user.real_name,
+                                                            display_name=slack_user.display_name,
+                                                            email=slack_user.email,
+                                                            image_72=slack_user.image_72,
+                                                            is_bot=str(slack_user.is_bot).lower(),
+                                                            is_admin=str(slack_user.is_admin).lower(),
+                                                            slack_team_id=slack_team.id)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createUserFromSlack'] is None
         assert response.json()['errors'][0]['message'] == "{'id': ['slack user with this id already exists.']}"
 
     @pytest.mark.django_db
-    def test_valid_and_gets_user(self, auth_client, mutation_generator, slack_team_factory, user_factory,
+    def test_valid_and_gets_user(self, auth_client, slack_team_factory, user_factory,
                                  slack_user_factory):
         slack_team = slack_team_factory()
         user = user_factory()
         slack_user = slack_user_factory.build(slack_team=slack_team, email=user.email)
 
-        mutation = mutation_generator.create_user_from_slack(id=slack_user.id, name=slack_user.name,
-                                                             first_name=slack_user.first_name,
-                                                             last_name=slack_user.last_name,
-                                                             real_name=slack_user.real_name,
-                                                             display_name=slack_user.display_name,
-                                                             email=slack_user.email,
-                                                             image_72=slack_user.image_72,
-                                                             is_bot=str(slack_user.is_bot).lower(),
-                                                             is_admin=str(slack_user.is_admin).lower(),
-                                                             slack_team_id=slack_team.id)
+        mutation = MutationGenerator.create_user_from_slack(id=slack_user.id, name=slack_user.name,
+                                                            first_name=slack_user.first_name,
+                                                            last_name=slack_user.last_name,
+                                                            real_name=slack_user.real_name,
+                                                            display_name=slack_user.display_name,
+                                                            email=slack_user.email,
+                                                            image_72=slack_user.image_72,
+                                                            is_bot=str(slack_user.is_bot).lower(),
+                                                            is_admin=str(slack_user.is_admin).lower(),
+                                                            slack_team_id=slack_team.id)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createUserFromSlack']['slackUser']['user']['id'] == str(user.id)
 
     @pytest.mark.django_db
-    def test_valid_and_creates_user(self, auth_client, mutation_generator, slack_team_factory, user_factory,
+    def test_valid_and_creates_user(self, auth_client, slack_team_factory, user_factory,
                                     slack_user_factory):
         slack_team = slack_team_factory()
         user = user_factory.build()
         slack_user = slack_user_factory.build(slack_team=slack_team, email=user.email)
 
-        mutation = mutation_generator.create_user_from_slack(id=slack_user.id, name=slack_user.name,
-                                                             first_name=slack_user.first_name,
-                                                             last_name=slack_user.last_name,
-                                                             real_name=slack_user.real_name,
-                                                             display_name=slack_user.display_name,
-                                                             email=slack_user.email,
-                                                             image_72=slack_user.image_72,
-                                                             is_bot=str(slack_user.is_bot).lower(),
-                                                             is_admin=str(slack_user.is_admin).lower(),
-                                                             slack_team_id=slack_team.id)
+        mutation = MutationGenerator.create_user_from_slack(id=slack_user.id, name=slack_user.name,
+                                                            first_name=slack_user.first_name,
+                                                            last_name=slack_user.last_name,
+                                                            real_name=slack_user.real_name,
+                                                            display_name=slack_user.display_name,
+                                                            email=slack_user.email,
+                                                            image_72=slack_user.image_72,
+                                                            is_bot=str(slack_user.is_bot).lower(),
+                                                            is_admin=str(slack_user.is_admin).lower(),
+                                                            slack_team_id=slack_team.id)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createUserFromSlack']['slackUser']['user']['alias']

--- a/tests/func/slack_integration/test_mark_discussion_as_pending_closed_from_slack.py
+++ b/tests/func/slack_integration/test_mark_discussion_as_pending_closed_from_slack.py
@@ -1,51 +1,53 @@
 import pytest
 
+from tests.resources.MutationGenerator import MutationGenerator
+
 
 class TestMarkDiscussionAsPendingClosedFromSlack:
 
     @pytest.mark.django_db
-    def test_unauthenticated(self, client, mutation_generator, slack_channel_factory):
+    def test_unauthenticated(self, client, slack_channel_factory):
         slack_channel = slack_channel_factory(discussion__topic__is_private=False, discussion__status='STALE')
 
-        mutation = mutation_generator.mark_discussion_as_pending_closed_from_slack(slack_channel.id)
+        mutation = MutationGenerator.mark_discussion_as_pending_closed_from_slack(slack_channel.id)
         response = client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['markDiscussionAsPendingClosedFromSlack'] is None
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_invalid_slack_channel(self, auth_client, mutation_generator, discussion_factory, slack_channel_factory):
+    def test_invalid_slack_channel(self, auth_client, discussion_factory, slack_channel_factory):
         discussion = discussion_factory(topic__is_private=False, status='STALE')
         slack_channel = slack_channel_factory.build(discussion=discussion)
 
-        mutation = mutation_generator.mark_discussion_as_pending_closed_from_slack(slack_channel.id)
+        mutation = MutationGenerator.mark_discussion_as_pending_closed_from_slack(slack_channel.id)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['markDiscussionAsPendingClosedFromSlack'] is None
         assert response.json()['errors'][0]['message'] == 'Discussion matching query does not exist.'
 
     @pytest.mark.django_db
-    def test_invalid_discussion_state(self, auth_client, mutation_generator, slack_channel_factory):
+    def test_invalid_discussion_state(self, auth_client, slack_channel_factory):
         slack_channel = slack_channel_factory(discussion__topic__is_private=False, discussion__status='OPEN')
 
-        mutation = mutation_generator.mark_discussion_as_pending_closed_from_slack(slack_channel.id)
+        mutation = MutationGenerator.mark_discussion_as_pending_closed_from_slack(slack_channel.id)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['markDiscussionAsPendingClosedFromSlack'] is None
         assert response.json()['errors'][0]['message'] == "Can't switch from state 'OPEN' using method " \
                                                           "'mark_as_pending_closed'"
 
     @pytest.mark.django_db
     @pytest.mark.usefixtures('auto_close_pending_closed_discussion_task', 'slack_app_request')
-    def test_valid(self, auth_client, mutation_generator, slack_channel_factory):
+    def test_valid(self, auth_client, slack_channel_factory):
         slack_channel = slack_channel_factory(discussion__topic__is_private=False, discussion__status='STALE')
 
-        mutation = mutation_generator.mark_discussion_as_pending_closed_from_slack(slack_channel.id)
+        mutation = MutationGenerator.mark_discussion_as_pending_closed_from_slack(slack_channel.id)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['markDiscussionAsPendingClosedFromSlack']['discussion'][
                    'status'] == 'PENDING CLOSED'

--- a/tests/func/slack_integration/test_mark_discussion_as_pending_closed_from_slack.py
+++ b/tests/func/slack_integration/test_mark_discussion_as_pending_closed_from_slack.py
@@ -4,37 +4,22 @@ import pytest
 class TestMarkDiscussionAsPendingClosedFromSlack:
 
     @pytest.mark.django_db
-    def test_unauthenticated(self, client, slack_channel_factory):
+    def test_unauthenticated(self, client, mutation_generator, slack_channel_factory):
         slack_channel = slack_channel_factory(discussion__topic__is_private=False, discussion__status='STALE')
 
-        mutation = f'''
-          mutation {{
-            markDiscussionAsPendingClosedFromSlack(input: {{slackChannelId: "{slack_channel.id}"}}) {{
-              discussion {{
-                status
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.mark_discussion_as_pending_closed_from_slack(slack_channel.id)
         response = client.post('/graphql', {'query': mutation})
+
         assert response.status_code == 200
         assert response.json()['data']['markDiscussionAsPendingClosedFromSlack'] is None
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_invalid_slack_channel(self, auth_client, discussion_factory, slack_channel_factory):
+    def test_invalid_slack_channel(self, auth_client, mutation_generator, discussion_factory, slack_channel_factory):
         discussion = discussion_factory(topic__is_private=False, status='STALE')
         slack_channel = slack_channel_factory.build(discussion=discussion)
 
-        mutation = f'''
-          mutation {{
-            markDiscussionAsPendingClosedFromSlack(input: {{slackChannelId: "{slack_channel.id}"}}) {{
-              discussion {{
-                status
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.mark_discussion_as_pending_closed_from_slack(slack_channel.id)
         response = auth_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200
@@ -42,18 +27,10 @@ class TestMarkDiscussionAsPendingClosedFromSlack:
         assert response.json()['errors'][0]['message'] == 'Discussion matching query does not exist.'
 
     @pytest.mark.django_db
-    def test_invalid_discussion_state(self, auth_client, slack_channel_factory):
+    def test_invalid_discussion_state(self, auth_client, mutation_generator, slack_channel_factory):
         slack_channel = slack_channel_factory(discussion__topic__is_private=False, discussion__status='OPEN')
 
-        mutation = f'''
-          mutation {{
-            markDiscussionAsPendingClosedFromSlack(input: {{slackChannelId: "{slack_channel.id}"}}) {{
-              discussion {{
-                status
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.mark_discussion_as_pending_closed_from_slack(slack_channel.id)
         response = auth_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200
@@ -63,18 +40,10 @@ class TestMarkDiscussionAsPendingClosedFromSlack:
 
     @pytest.mark.django_db
     @pytest.mark.usefixtures('auto_close_pending_closed_discussion_task', 'slack_app_request')
-    def test_valid(self, auth_client, slack_channel_factory):
+    def test_valid(self, auth_client, mutation_generator, slack_channel_factory):
         slack_channel = slack_channel_factory(discussion__topic__is_private=False, discussion__status='STALE')
 
-        mutation = f'''
-          mutation {{
-            markDiscussionAsPendingClosedFromSlack(input: {{slackChannelId: "{slack_channel.id}"}}) {{
-              discussion {{
-                status
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.mark_discussion_as_pending_closed_from_slack(slack_channel.id)
         response = auth_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200

--- a/tests/func/slack_integration/test_mark_discussion_as_pending_closed_from_slack.py
+++ b/tests/func/slack_integration/test_mark_discussion_as_pending_closed_from_slack.py
@@ -62,8 +62,8 @@ class TestMarkDiscussionAsPendingClosedFromSlack:
                                                           "'mark_as_pending_closed'"
 
     @pytest.mark.django_db
-    def test_valid(self, auth_client, slack_channel_factory, auto_close_pending_closed_discussion_factory,
-                   slack_app_request_factory):
+    @pytest.mark.usefixtures('auto_close_pending_closed_discussion_task', 'slack_app_request')
+    def test_valid(self, auth_client, slack_channel_factory):
         slack_channel = slack_channel_factory(discussion__topic__is_private=False, discussion__status='STALE')
 
         mutation = f'''

--- a/tests/func/slack_integration/test_query_slack_application_installations.py
+++ b/tests/func/slack_integration/test_query_slack_application_installations.py
@@ -4,38 +4,39 @@ import pytest
 class TestQuerySlackApplicationInstallations:
 
     @pytest.mark.django_db
-    def test_get_slack_application_installation(self, slack_application_installation_factory, auth_client):
+    def test_get_slack_application_installation(self, auth_client, query_generator,
+                                                slack_application_installation_factory):
         slack_application_installation = slack_application_installation_factory()
 
-        query = {'query': f'{{ slackApplicationInstallation(id: {slack_application_installation.id}) '
-                          f'{{ botAccessToken }} }}'}
-        response = auth_client.post('/graphql', query)
+        query = query_generator.get_slack_application_installation(slack_application_installation.id)
+        response = auth_client.post('/graphql', {'query': query})
 
         assert response.status_code == 200
         assert response.json()['data']['slackApplicationInstallation']['botAccessToken'] == \
             slack_application_installation.bot_access_token
 
     @pytest.mark.django_db
-    def test_get_slack_application_installations(self, slack_application_installation_factory, auth_client):
+    def test_get_slack_application_installations(self, auth_client, query_generator,
+                                                 slack_application_installation_factory):
         slack_application_installation_factory()
         slack_application_installation_factory()
 
-        query = {'query': '{ slackApplicationInstallations { botAccessToken } }'}
-        response = auth_client.post('/graphql', query)
+        query = query_generator.get_slack_application_installations()
+        response = auth_client.post('/graphql', {'query': query})
 
         assert response.status_code == 200
         assert len(response.json()['data']['slackApplicationInstallations']) == 2
 
     @pytest.mark.django_db
-    def test_get_active_slack_application_installations(self, auth_client, slack_agent_factory,
+    def test_get_active_slack_application_installations(self, auth_client, query_generator, slack_agent_factory,
                                                         slack_application_installation_factory):
         slack_agent_one = slack_agent_factory(status='INITIATED')
         slack_application_installation_factory(slack_agent=slack_agent_one)
         slack_agent_two = slack_agent_factory(status='ACTIVE')
         slack_application_installation_factory(slack_agent=slack_agent_two)
 
-        query = {'query': '{ slackApplicationInstallations (agentStatus: "ACTIVE") { botAccessToken } }'}
-        response = auth_client.post('/graphql', query)
+        query = query_generator.get_active_slack_application_installations()
+        response = auth_client.post('/graphql', {'query': query})
 
         assert response.status_code == 200
         assert len(response.json()['data']['slackApplicationInstallations']) == 1

--- a/tests/func/slack_integration/test_query_slack_application_installations.py
+++ b/tests/func/slack_integration/test_query_slack_application_installations.py
@@ -1,42 +1,42 @@
 import pytest
 
+from tests.resources.QueryGenerator import QueryGenerator
+
 
 class TestQuerySlackApplicationInstallations:
 
     @pytest.mark.django_db
-    def test_get_slack_application_installation(self, auth_client, query_generator,
-                                                slack_application_installation_factory):
+    def test_get_slack_application_installation(self, auth_client, slack_application_installation_factory):
         slack_application_installation = slack_application_installation_factory()
 
-        query = query_generator.get_slack_application_installation(slack_application_installation.id)
+        query = QueryGenerator.get_slack_application_installation(slack_application_installation.id)
         response = auth_client.post('/graphql', {'query': query})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['slackApplicationInstallation']['botAccessToken'] == \
             slack_application_installation.bot_access_token
 
     @pytest.mark.django_db
-    def test_get_slack_application_installations(self, auth_client, query_generator,
-                                                 slack_application_installation_factory):
+    def test_get_slack_application_installations(self, auth_client, slack_application_installation_factory):
         slack_application_installation_factory()
         slack_application_installation_factory()
 
-        query = query_generator.get_slack_application_installations()
+        query = QueryGenerator.get_slack_application_installations()
         response = auth_client.post('/graphql', {'query': query})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert len(response.json()['data']['slackApplicationInstallations']) == 2
 
     @pytest.mark.django_db
-    def test_get_active_slack_application_installations(self, auth_client, query_generator, slack_agent_factory,
+    def test_get_active_slack_application_installations(self, auth_client, slack_agent_factory,
                                                         slack_application_installation_factory):
         slack_agent_one = slack_agent_factory(status='INITIATED')
         slack_application_installation_factory(slack_agent=slack_agent_one)
         slack_agent_two = slack_agent_factory(status='ACTIVE')
         slack_application_installation_factory(slack_agent=slack_agent_two)
 
-        query = query_generator.get_active_slack_application_installations()
+        query = QueryGenerator.get_active_slack_application_installations()
         response = auth_client.post('/graphql', {'query': query})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert len(response.json()['data']['slackApplicationInstallations']) == 1

--- a/tests/func/slack_integration/test_query_slack_channels.py
+++ b/tests/func/slack_integration/test_query_slack_channels.py
@@ -4,22 +4,22 @@ import pytest
 class TestQuerySlackChannels:
 
     @pytest.mark.django_db
-    def test_get_slack_channel(self, slack_channel_factory, client):
+    def test_get_slack_channel(self, client, query_generator, slack_channel_factory):
         slack_channel = slack_channel_factory()
 
-        query = {'query': f'{{ slackChannel(id: "{slack_channel.id}") {{ name }} }}'}
-        response = client.post('/graphql', query)
+        query = query_generator.get_slack_channel(slack_channel.id)
+        response = client.post('/graphql', {'query': query})
 
         assert response.status_code == 200
         assert response.json()['data']['slackChannel']['name'] == slack_channel.name
 
     @pytest.mark.django_db
-    def test_get_slack_channels(self, slack_channel_factory, client):
+    def test_get_slack_channels(self, client, query_generator, slack_channel_factory):
         slack_channel_factory()
         slack_channel_factory()
 
-        query = {'query': '{ slackChannels { name } }'}
-        response = client.post('/graphql', query)
+        query = query_generator.get_slack_channels()
+        response = client.post('/graphql', {'query': query})
 
         assert response.status_code == 200
         assert len(response.json()['data']['slackChannels']) == 2

--- a/tests/func/slack_integration/test_query_slack_channels.py
+++ b/tests/func/slack_integration/test_query_slack_channels.py
@@ -1,25 +1,27 @@
 import pytest
 
+from tests.resources.QueryGenerator import QueryGenerator
+
 
 class TestQuerySlackChannels:
 
     @pytest.mark.django_db
-    def test_get_slack_channel(self, client, query_generator, slack_channel_factory):
+    def test_get_slack_channel(self, client, slack_channel_factory):
         slack_channel = slack_channel_factory()
 
-        query = query_generator.get_slack_channel(slack_channel.id)
+        query = QueryGenerator.get_slack_channel(slack_channel.id)
         response = client.post('/graphql', {'query': query})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['slackChannel']['name'] == slack_channel.name
 
     @pytest.mark.django_db
-    def test_get_slack_channels(self, client, query_generator, slack_channel_factory):
+    def test_get_slack_channels(self, client, slack_channel_factory):
         slack_channel_factory()
         slack_channel_factory()
 
-        query = query_generator.get_slack_channels()
+        query = QueryGenerator.get_slack_channels()
         response = client.post('/graphql', {'query': query})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert len(response.json()['data']['slackChannels']) == 2

--- a/tests/func/slack_integration/test_query_slack_teams.py
+++ b/tests/func/slack_integration/test_query_slack_teams.py
@@ -1,25 +1,27 @@
 import pytest
 
+from tests.resources.QueryGenerator import QueryGenerator
+
 
 class TestQuerySlackTeams:
 
     @pytest.mark.django_db
-    def test_get_slack_team(self, client, query_generator, slack_team_factory):
+    def test_get_slack_team(self, client, slack_team_factory):
         slack_team = slack_team_factory()
 
-        query = query_generator.get_slack_team(slack_team.id)
+        query = QueryGenerator.get_slack_team(slack_team.id)
         response = client.post('/graphql', {'query': query})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['slackTeam']['name'] == slack_team.name
 
     @pytest.mark.django_db
-    def test_get_slack_teams(self, client, query_generator, slack_team_factory):
+    def test_get_slack_teams(self, client, slack_team_factory):
         slack_team_factory()
         slack_team_factory()
 
-        query = query_generator.get_slack_teams()
+        query = QueryGenerator.get_slack_teams()
         response = client.post('/graphql', {'query': query})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert len(response.json()['data']['slackTeams']) == 2

--- a/tests/func/slack_integration/test_query_slack_teams.py
+++ b/tests/func/slack_integration/test_query_slack_teams.py
@@ -4,22 +4,22 @@ import pytest
 class TestQuerySlackTeams:
 
     @pytest.mark.django_db
-    def test_get_slack_team(self, slack_team_factory, client):
+    def test_get_slack_team(self, client, query_generator, slack_team_factory):
         slack_team = slack_team_factory()
 
-        query = {'query': f'{{ slackTeam(id: "{slack_team.id}") {{ name }} }}'}
-        response = client.post('/graphql', query)
+        query = query_generator.get_slack_team(slack_team.id)
+        response = client.post('/graphql', {'query': query})
 
         assert response.status_code == 200
         assert response.json()['data']['slackTeam']['name'] == slack_team.name
 
     @pytest.mark.django_db
-    def test_get_slack_teams(self, slack_team_factory, client):
+    def test_get_slack_teams(self, client, query_generator, slack_team_factory):
         slack_team_factory()
         slack_team_factory()
 
-        query = {'query': '{ slackTeams { slackAgent { group { name } } } }'}
-        response = client.post('/graphql', query)
+        query = query_generator.get_slack_teams()
+        response = client.post('/graphql', {'query': query})
 
         assert response.status_code == 200
         assert len(response.json()['data']['slackTeams']) == 2

--- a/tests/func/slack_integration/test_query_slack_users.py
+++ b/tests/func/slack_integration/test_query_slack_users.py
@@ -4,68 +4,42 @@ import pytest
 class TestQuerySlackUsers:
 
     @pytest.mark.django_db
-    def test_get_slack_user_unauthorized(self, slack_user_factory, client):
+    def test_get_slack_user_unauthorized(self, client, query_generator, slack_user_factory):
         slack_user = slack_user_factory()
 
-        query = f'''{{
-          slackUser(id: "{slack_user.id}") {{
-            displayName
-            id
-          }}
-        }}'''
+        query = query_generator.get_slack_user(slack_user.id)
         response = client.post('/graphql', {'query': query})
 
         assert response.status_code == 200
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_get_slack_user(self, slack_user_factory, auth_client):
+    def test_get_slack_user(self, auth_client, query_generator, slack_user_factory):
         slack_user = slack_user_factory()
 
-        query = f'''{{
-          slackUser(id: "{slack_user.id}") {{
-            id
-            displayName
-            slackTeam {{
-              name
-            }}
-            user {{
-              id
-            }}
-          }}
-        }}'''
+        query = query_generator.get_slack_user(slack_user.id)
         response = auth_client.post('/graphql', {'query': query})
 
         assert response.status_code == 200
         assert response.json()['data']['slackUser']['displayName'] == slack_user.display_name
 
     @pytest.mark.django_db
-    def test_get_slack_users_unauthorized(self, slack_user_factory, client):
+    def test_get_slack_users_unauthorized(self, client, query_generator, slack_user_factory):
         slack_user_factory()
         slack_user_factory()
 
-        query = '''{
-          slackUsers {
-            id
-          }
-        }'''
+        query = query_generator.get_slack_users()
         response = client.post('/graphql', {'query': query})
 
         assert response.status_code == 200
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_get_slack_users(self, slack_user_factory, auth_client):
+    def test_get_slack_users(self, auth_client, query_generator, slack_user_factory):
         slack_user_factory()
         slack_user_factory()
 
-        query = '''{
-          slackUsers {
-            user {
-              id
-            }
-          }
-        }'''
+        query = query_generator.get_slack_users()
         response = auth_client.post('/graphql', {'query': query})
 
         assert response.status_code == 200

--- a/tests/func/slack_integration/test_query_slack_users.py
+++ b/tests/func/slack_integration/test_query_slack_users.py
@@ -1,46 +1,48 @@
 import pytest
 
+from tests.resources.QueryGenerator import QueryGenerator
+
 
 class TestQuerySlackUsers:
 
     @pytest.mark.django_db
-    def test_get_slack_user_unauthorized(self, client, query_generator, slack_user_factory):
+    def test_get_slack_user_unauthorized(self, client, slack_user_factory):
         slack_user = slack_user_factory()
 
-        query = query_generator.get_slack_user(slack_user.id)
+        query = QueryGenerator.get_slack_user(slack_user.id)
         response = client.post('/graphql', {'query': query})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_get_slack_user(self, auth_client, query_generator, slack_user_factory):
+    def test_get_slack_user(self, auth_client, slack_user_factory):
         slack_user = slack_user_factory()
 
-        query = query_generator.get_slack_user(slack_user.id)
+        query = QueryGenerator.get_slack_user(slack_user.id)
         response = auth_client.post('/graphql', {'query': query})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['slackUser']['displayName'] == slack_user.display_name
 
     @pytest.mark.django_db
-    def test_get_slack_users_unauthorized(self, client, query_generator, slack_user_factory):
+    def test_get_slack_users_unauthorized(self, client, slack_user_factory):
         slack_user_factory()
         slack_user_factory()
 
-        query = query_generator.get_slack_users()
+        query = QueryGenerator.get_slack_users()
         response = client.post('/graphql', {'query': query})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_get_slack_users(self, auth_client, query_generator, slack_user_factory):
+    def test_get_slack_users(self, auth_client, slack_user_factory):
         slack_user_factory()
         slack_user_factory()
 
-        query = query_generator.get_slack_users()
+        query = QueryGenerator.get_slack_users()
         response = auth_client.post('/graphql', {'query': query})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert len(response.json()['data']['slackUsers']) == 2

--- a/tests/func/slack_integration/test_update_slack_agent_topic_channel_and_activate.py
+++ b/tests/func/slack_integration/test_update_slack_agent_topic_channel_and_activate.py
@@ -1,10 +1,12 @@
 import pytest
 
+from tests.resources.MutationGenerator import MutationGenerator
+
 
 class TestUpdateSlackAgentTopicChannelAndActivate:
 
     @pytest.mark.django_db
-    def test_unauthenticated(self, client, mutation_generator, slack_agent_factory, slack_team_factory,
+    def test_unauthenticated(self, client, slack_agent_factory, slack_team_factory,
                              slack_application_installation_factory, slack_app_request):
         slack_agent = slack_agent_factory(topic_channel_id=None)
         slack_application_installation_factory(slack_agent=slack_agent)
@@ -17,16 +19,16 @@ class TestUpdateSlackAgentTopicChannelAndActivate:
         slack_team = slack_team_factory(slack_agent=slack_agent)
         topic_channel_id = slack_agent_factory.build().topic_channel_id
 
-        mutation = mutation_generator.update_slack_agent_topic_channel_and_activate(slack_team_id=slack_team.id,
-                                                                                    topic_channel_id=topic_channel_id)
+        mutation = MutationGenerator.update_slack_agent_topic_channel_and_activate(slack_team_id=slack_team.id,
+                                                                                   topic_channel_id=topic_channel_id)
         response = client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['updateSlackAgentTopicChannelAndActivate'] is None
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_invalid_slack_team(self, auth_client, mutation_generator, slack_application_installation_factory,
+    def test_invalid_slack_team(self, auth_client, slack_application_installation_factory,
                                 slack_agent_factory, slack_team_factory, slack_app_request):
         slack_agent = slack_agent_factory(topic_channel_id=None)
         slack_application_installation_factory(slack_agent=slack_agent)
@@ -39,31 +41,31 @@ class TestUpdateSlackAgentTopicChannelAndActivate:
         slack_team = slack_team_factory.build(slack_agent=slack_agent)
         topic_channel_id = slack_agent_factory.build().topic_channel_id
 
-        mutation = mutation_generator.update_slack_agent_topic_channel_and_activate(slack_team_id=slack_team.id,
-                                                                                    topic_channel_id=topic_channel_id)
+        mutation = MutationGenerator.update_slack_agent_topic_channel_and_activate(slack_team_id=slack_team.id,
+                                                                                   topic_channel_id=topic_channel_id)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['updateSlackAgentTopicChannelAndActivate'] is None
         assert response.json()['errors'][0]['message'] == 'SlackAgent matching query does not exist.'
 
     @pytest.mark.django_db
-    def test_invalid_slack_agent_status(self, auth_client, mutation_generator, slack_agent_factory, slack_team_factory):
+    def test_invalid_slack_agent_status(self, auth_client, slack_agent_factory, slack_team_factory):
         slack_agent = slack_agent_factory(topic_channel_id=None)
 
         slack_team = slack_team_factory(slack_agent=slack_agent)
         topic_channel_id = slack_agent_factory.build().topic_channel_id
 
-        mutation = mutation_generator.update_slack_agent_topic_channel_and_activate(slack_team_id=slack_team.id,
-                                                                                    topic_channel_id=topic_channel_id)
+        mutation = MutationGenerator.update_slack_agent_topic_channel_and_activate(slack_team_id=slack_team.id,
+                                                                                   topic_channel_id=topic_channel_id)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['updateSlackAgentTopicChannelAndActivate'] is None
         assert response.json()['errors'][0]['message'] == "Can't switch from state 'INITIATED' using method 'activate'"
 
     @pytest.mark.django_db
-    def test_valid(self, auth_client, mutation_generator, slack_application_installation_factory, slack_agent_factory,
+    def test_valid(self, auth_client, slack_application_installation_factory, slack_agent_factory,
                    slack_team_factory, slack_app_request):
         slack_agent = slack_agent_factory(topic_channel_id=None)
         slack_application_installation_factory(slack_agent=slack_agent)
@@ -76,11 +78,11 @@ class TestUpdateSlackAgentTopicChannelAndActivate:
         slack_team = slack_team_factory(slack_agent=slack_agent)
         topic_channel_id = slack_agent_factory.build().topic_channel_id
 
-        mutation = mutation_generator.update_slack_agent_topic_channel_and_activate(slack_team_id=slack_team.id,
-                                                                                    topic_channel_id=topic_channel_id)
+        mutation = MutationGenerator.update_slack_agent_topic_channel_and_activate(slack_team_id=slack_team.id,
+                                                                                   topic_channel_id=topic_channel_id)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['updateSlackAgentTopicChannelAndActivate']['slackAgent'][
                    'topicChannelId'] == topic_channel_id
         assert response.json()['data']['updateSlackAgentTopicChannelAndActivate']['slackAgent']['status'] == 'ACTIVE'

--- a/tests/func/slack_integration/test_update_slack_agent_topic_channel_and_activate.py
+++ b/tests/func/slack_integration/test_update_slack_agent_topic_channel_and_activate.py
@@ -5,14 +5,14 @@ class TestUpdateSlackAgentTopicChannelAndActivate:
 
     @pytest.mark.django_db
     def test_unauthenticated(self, client, slack_agent_factory, slack_team_factory,
-                             slack_application_installation_factory, slack_app_request_factory):
+                             slack_application_installation_factory, slack_app_request):
         slack_agent = slack_agent_factory(topic_channel_id=None)
         slack_application_installation_factory(slack_agent=slack_agent)
         slack_agent.authenticate()
         slack_agent.save()
 
-        assert len(slack_app_request_factory.calls) == 1
-        assert slack_app_request_factory.calls[0].request.method == 'POST'
+        assert len(slack_app_request.calls) == 1
+        assert slack_app_request.calls[0].request.method == 'POST'
 
         slack_team = slack_team_factory(slack_agent=slack_agent)
         topic_channel_id = slack_agent_factory.build().topic_channel_id
@@ -35,14 +35,14 @@ class TestUpdateSlackAgentTopicChannelAndActivate:
 
     @pytest.mark.django_db
     def test_invalid_slack_team(self, auth_client, slack_application_installation_factory, slack_agent_factory,
-                                slack_team_factory, slack_app_request_factory):
+                                slack_team_factory, slack_app_request):
         slack_agent = slack_agent_factory(topic_channel_id=None)
         slack_application_installation_factory(slack_agent=slack_agent)
         slack_agent.authenticate()
         slack_agent.save()
 
-        assert len(slack_app_request_factory.calls) == 1
-        assert slack_app_request_factory.calls[0].request.method == 'POST'
+        assert len(slack_app_request.calls) == 1
+        assert slack_app_request.calls[0].request.method == 'POST'
 
         slack_team = slack_team_factory.build(slack_agent=slack_agent)
         topic_channel_id = slack_agent_factory.build().topic_channel_id
@@ -89,14 +89,14 @@ class TestUpdateSlackAgentTopicChannelAndActivate:
 
     @pytest.mark.django_db
     def test_valid(self, auth_client, slack_application_installation_factory, slack_agent_factory, slack_team_factory,
-                   slack_app_request_factory):
+                   slack_app_request):
         slack_agent = slack_agent_factory(topic_channel_id=None)
         slack_application_installation_factory(slack_agent=slack_agent)
         slack_agent.authenticate()
         slack_agent.save()
 
-        assert len(slack_app_request_factory.calls) == 1
-        assert slack_app_request_factory.calls[0].request.method == 'POST'
+        assert len(slack_app_request.calls) == 1
+        assert slack_app_request.calls[0].request.method == 'POST'
 
         slack_team = slack_team_factory(slack_agent=slack_agent)
         topic_channel_id = slack_agent_factory.build().topic_channel_id
@@ -119,5 +119,5 @@ class TestUpdateSlackAgentTopicChannelAndActivate:
                    'topicChannelId'] == topic_channel_id
         assert response.json()['data']['updateSlackAgentTopicChannelAndActivate']['slackAgent']['status'] == 'ACTIVE'
 
-        assert len(slack_app_request_factory.calls) == 2
-        assert slack_app_request_factory.calls[1].request.method == 'PUT'
+        assert len(slack_app_request.calls) == 2
+        assert slack_app_request.calls[1].request.method == 'PUT'

--- a/tests/func/slack_integration/test_update_slack_agent_topic_channel_and_activate.py
+++ b/tests/func/slack_integration/test_update_slack_agent_topic_channel_and_activate.py
@@ -4,7 +4,7 @@ import pytest
 class TestUpdateSlackAgentTopicChannelAndActivate:
 
     @pytest.mark.django_db
-    def test_unauthenticated(self, client, slack_agent_factory, slack_team_factory,
+    def test_unauthenticated(self, client, mutation_generator, slack_agent_factory, slack_team_factory,
                              slack_application_installation_factory, slack_app_request):
         slack_agent = slack_agent_factory(topic_channel_id=None)
         slack_application_installation_factory(slack_agent=slack_agent)
@@ -17,16 +17,8 @@ class TestUpdateSlackAgentTopicChannelAndActivate:
         slack_team = slack_team_factory(slack_agent=slack_agent)
         topic_channel_id = slack_agent_factory.build().topic_channel_id
 
-        mutation = f'''
-          mutation {{
-            updateSlackAgentTopicChannelAndActivate(input: {{slackTeamId: "{slack_team.id}",
-                                                            topicChannelId: "{topic_channel_id}"}}) {{
-              slackAgent {{
-                topicChannelId
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.update_slack_agent_topic_channel_and_activate(slack_team_id=slack_team.id,
+                                                                                    topic_channel_id=topic_channel_id)
         response = client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200
@@ -34,8 +26,8 @@ class TestUpdateSlackAgentTopicChannelAndActivate:
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_invalid_slack_team(self, auth_client, slack_application_installation_factory, slack_agent_factory,
-                                slack_team_factory, slack_app_request):
+    def test_invalid_slack_team(self, auth_client, mutation_generator, slack_application_installation_factory,
+                                slack_agent_factory, slack_team_factory, slack_app_request):
         slack_agent = slack_agent_factory(topic_channel_id=None)
         slack_application_installation_factory(slack_agent=slack_agent)
         slack_agent.authenticate()
@@ -47,16 +39,8 @@ class TestUpdateSlackAgentTopicChannelAndActivate:
         slack_team = slack_team_factory.build(slack_agent=slack_agent)
         topic_channel_id = slack_agent_factory.build().topic_channel_id
 
-        mutation = f'''
-          mutation {{
-            updateSlackAgentTopicChannelAndActivate(input: {{slackTeamId: "{slack_team.id}",
-                                                            topicChannelId: "{topic_channel_id}"}}) {{
-              slackAgent {{
-                topicChannelId
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.update_slack_agent_topic_channel_and_activate(slack_team_id=slack_team.id,
+                                                                                    topic_channel_id=topic_channel_id)
         response = auth_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200
@@ -64,23 +48,14 @@ class TestUpdateSlackAgentTopicChannelAndActivate:
         assert response.json()['errors'][0]['message'] == 'SlackAgent matching query does not exist.'
 
     @pytest.mark.django_db
-    def test_invalid_slack_agent_status(self, auth_client, slack_agent_factory, slack_team_factory):
+    def test_invalid_slack_agent_status(self, auth_client, mutation_generator, slack_agent_factory, slack_team_factory):
         slack_agent = slack_agent_factory(topic_channel_id=None)
 
         slack_team = slack_team_factory(slack_agent=slack_agent)
         topic_channel_id = slack_agent_factory.build().topic_channel_id
 
-        mutation = f'''
-          mutation {{
-            updateSlackAgentTopicChannelAndActivate(input: {{slackTeamId: "{slack_team.id}",
-                                                            topicChannelId: "{topic_channel_id}"}}) {{
-              slackAgent {{
-                topicChannelId
-                status
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.update_slack_agent_topic_channel_and_activate(slack_team_id=slack_team.id,
+                                                                                    topic_channel_id=topic_channel_id)
         response = auth_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200
@@ -88,8 +63,8 @@ class TestUpdateSlackAgentTopicChannelAndActivate:
         assert response.json()['errors'][0]['message'] == "Can't switch from state 'INITIATED' using method 'activate'"
 
     @pytest.mark.django_db
-    def test_valid(self, auth_client, slack_application_installation_factory, slack_agent_factory, slack_team_factory,
-                   slack_app_request):
+    def test_valid(self, auth_client, mutation_generator, slack_application_installation_factory, slack_agent_factory,
+                   slack_team_factory, slack_app_request):
         slack_agent = slack_agent_factory(topic_channel_id=None)
         slack_application_installation_factory(slack_agent=slack_agent)
         slack_agent.authenticate()
@@ -101,17 +76,8 @@ class TestUpdateSlackAgentTopicChannelAndActivate:
         slack_team = slack_team_factory(slack_agent=slack_agent)
         topic_channel_id = slack_agent_factory.build().topic_channel_id
 
-        mutation = f'''
-          mutation {{
-            updateSlackAgentTopicChannelAndActivate(input: {{slackTeamId: "{slack_team.id}",
-                                                            topicChannelId: "{topic_channel_id}"}}) {{
-              slackAgent {{
-                topicChannelId
-                status
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.update_slack_agent_topic_channel_and_activate(slack_team_id=slack_team.id,
+                                                                                    topic_channel_id=topic_channel_id)
         response = auth_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200

--- a/tests/func/topics/test_close_discussion.py
+++ b/tests/func/topics/test_close_discussion.py
@@ -1,36 +1,38 @@
 import pytest
 
+from tests.resources.MutationGenerator import MutationGenerator
+
 
 class TestCloseDiscussion:
 
     @pytest.mark.django_db
-    def test_unauthenticated(self, client, mutation_generator, discussion_factory):
+    def test_unauthenticated(self, client, discussion_factory):
         discussion = discussion_factory(topic__is_private=False)
 
-        mutation = mutation_generator.close_discussion(discussion_id=discussion.id)
+        mutation = MutationGenerator.close_discussion(discussion_id=discussion.id)
         response = client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['closeDiscussion'] is None
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_invalid_discussion(self, auth_client, mutation_generator, discussion_factory):
+    def test_invalid_discussion(self, auth_client, discussion_factory):
         discussion = discussion_factory(topic__is_private=False)
 
-        mutation = mutation_generator.close_discussion(discussion_id=discussion.id + 1)
+        mutation = MutationGenerator.close_discussion(discussion_id=discussion.id + 1)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['closeDiscussion'] is None
         assert response.json()['errors'][0]['message'] == 'Discussion matching query does not exist.'
 
     @pytest.mark.django_db
-    def test_valid(self, auth_client, mutation_generator, discussion_factory):
+    def test_valid(self, auth_client, discussion_factory):
         discussion = discussion_factory(topic__is_private=False)
 
-        mutation = mutation_generator.close_discussion(discussion_id=discussion.id)
+        mutation = MutationGenerator.close_discussion(discussion_id=discussion.id)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['closeDiscussion']['discussion']['id'] == str(discussion.id)

--- a/tests/func/topics/test_close_discussion.py
+++ b/tests/func/topics/test_close_discussion.py
@@ -4,18 +4,10 @@ import pytest
 class TestCloseDiscussion:
 
     @pytest.mark.django_db
-    def test_unauthenticated(self, client, discussion_factory):
+    def test_unauthenticated(self, client, mutation_generator, discussion_factory):
         discussion = discussion_factory(topic__is_private=False)
 
-        mutation = f'''
-          mutation {{
-            closeDiscussion(input: {{id: {discussion.id}}}) {{
-              discussion {{
-                timeEnd
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.close_discussion(discussion_id=discussion.id)
         response = client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200
@@ -23,18 +15,10 @@ class TestCloseDiscussion:
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_invalid_discussion(self, auth_client, discussion_factory):
+    def test_invalid_discussion(self, auth_client, mutation_generator, discussion_factory):
         discussion = discussion_factory(topic__is_private=False)
 
-        mutation = f'''
-          mutation {{
-            closeDiscussion(input: {{id: {discussion.id + 1}}}) {{
-              discussion {{
-                timeEnd
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.close_discussion(discussion_id=discussion.id + 1)
         response = auth_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200
@@ -42,19 +26,10 @@ class TestCloseDiscussion:
         assert response.json()['errors'][0]['message'] == 'Discussion matching query does not exist.'
 
     @pytest.mark.django_db
-    def test_valid(self, auth_client, discussion_factory):
+    def test_valid(self, auth_client, mutation_generator, discussion_factory):
         discussion = discussion_factory(topic__is_private=False)
 
-        mutation = f'''
-          mutation {{
-            closeDiscussion(input: {{id: {discussion.id}}}) {{
-              discussion {{
-                id
-                timeEnd
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.close_discussion(discussion_id=discussion.id)
         response = auth_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200

--- a/tests/func/topics/test_create_discussion.py
+++ b/tests/func/topics/test_create_discussion.py
@@ -1,31 +1,33 @@
 import pytest
 
+from tests.resources.MutationGenerator import MutationGenerator
+
 
 class TestCreateDiscussion:
 
     @pytest.mark.django_db
-    def test_unauthenticated(self, client, mutation_generator, topic_factory, discussion_factory):
+    def test_unauthenticated(self, client, topic_factory, discussion_factory):
         topic = topic_factory(is_private=False)
         discussion = discussion_factory.build()
 
-        mutation = mutation_generator.create_discussion(time_start=discussion.time_start,
-                                                        time_end=discussion.time_end,
-                                                        topic_id=topic.id)
+        mutation = MutationGenerator.create_discussion(time_start=discussion.time_start,
+                                                       time_end=discussion.time_end,
+                                                       topic_id=topic.id)
         response = client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createDiscussion'] is None
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_valid(self, auth_client, mutation_generator, topic_factory, discussion_factory):
+    def test_valid(self, auth_client, topic_factory, discussion_factory):
         topic = topic_factory(is_private=False)
         discussion = discussion_factory.build()
 
-        mutation = mutation_generator.create_discussion(time_start=discussion.time_start,
-                                                        time_end=discussion.time_end,
-                                                        topic_id=topic.id)
+        mutation = MutationGenerator.create_discussion(time_start=discussion.time_start,
+                                                       time_end=discussion.time_end,
+                                                       topic_id=topic.id)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createDiscussion']['discussion']['topic']['id'] == str(topic.id)

--- a/tests/func/topics/test_create_discussion.py
+++ b/tests/func/topics/test_create_discussion.py
@@ -4,22 +4,13 @@ import pytest
 class TestCreateDiscussion:
 
     @pytest.mark.django_db
-    def test_unauthenticated(self, client, topic_factory, discussion_factory):
+    def test_unauthenticated(self, client, mutation_generator, topic_factory, discussion_factory):
         topic = topic_factory(is_private=False)
         discussion = discussion_factory.build()
 
-        mutation = f'''
-          mutation {{
-            createDiscussion(input: {{timeStart: "{discussion.time_start}", timeEnd: "{discussion.time_end}",
-                                      topicId: {topic.id}}}) {{
-              discussion {{
-                topic {{
-                  id
-                }}
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_discussion(time_start=discussion.time_start,
+                                                        time_end=discussion.time_end,
+                                                        topic_id=topic.id)
         response = client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200
@@ -27,22 +18,13 @@ class TestCreateDiscussion:
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_valid(self, auth_client, topic_factory, discussion_factory):
+    def test_valid(self, auth_client, mutation_generator, topic_factory, discussion_factory):
         topic = topic_factory(is_private=False)
         discussion = discussion_factory.build()
 
-        mutation = f'''
-          mutation {{
-            createDiscussion(input: {{timeStart: "{discussion.time_start}", timeEnd: "{discussion.time_end}",
-                                   topicId: {topic.id}}}) {{
-              discussion {{
-                topic {{
-                  id
-                }}
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_discussion(time_start=discussion.time_start,
+                                                        time_end=discussion.time_end,
+                                                        topic_id=topic.id)
         response = auth_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200

--- a/tests/func/topics/test_create_tag.py
+++ b/tests/func/topics/test_create_tag.py
@@ -4,18 +4,10 @@ import pytest
 class TestCreateTag:
 
     @pytest.mark.django_db
-    def test_unauthenticated(self, client, tag_factory):
+    def test_unauthenticated(self, client, mutation_generator, tag_factory):
         tag = tag_factory.build()
 
-        mutation = f'''
-          mutation {{
-            createTag(input: {{name: "{tag.name}"}}) {{
-              tag {{
-                name
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_tag(name=tag.name)
         response = client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200
@@ -23,18 +15,10 @@ class TestCreateTag:
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_valid(self, auth_client, tag_factory):
+    def test_valid(self, auth_client, mutation_generator, tag_factory):
         tag = tag_factory.build()
 
-        mutation = f'''
-          mutation {{
-            createTag(input: {{name: "{tag.name}"}}) {{
-              tag {{
-                name
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_tag(name=tag.name)
         response = auth_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200

--- a/tests/func/topics/test_create_tag.py
+++ b/tests/func/topics/test_create_tag.py
@@ -1,25 +1,27 @@
 import pytest
 
+from tests.resources.MutationGenerator import MutationGenerator
+
 
 class TestCreateTag:
 
     @pytest.mark.django_db
-    def test_unauthenticated(self, client, mutation_generator, tag_factory):
+    def test_unauthenticated(self, client, tag_factory):
         tag = tag_factory.build()
 
-        mutation = mutation_generator.create_tag(name=tag.name)
+        mutation = MutationGenerator.create_tag(name=tag.name)
         response = client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createTag'] is None
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_valid(self, auth_client, mutation_generator, tag_factory):
+    def test_valid(self, auth_client, tag_factory):
         tag = tag_factory.build()
 
-        mutation = mutation_generator.create_tag(name=tag.name)
+        mutation = MutationGenerator.create_tag(name=tag.name)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createTag']['tag']['name'] == tag.name

--- a/tests/func/topics/test_create_topic.py
+++ b/tests/func/topics/test_create_topic.py
@@ -1,39 +1,41 @@
 import pytest
 
+from tests.resources.MutationGenerator import MutationGenerator
+
 
 class TestCreateTopic:
 
     @pytest.mark.django_db
-    def test_unauthenticated(self, client, mutation_generator, topic_factory, user_factory, group_factory):
+    def test_unauthenticated(self, client, topic_factory, user_factory, group_factory):
         group = group_factory()
         user = user_factory()
         topic = topic_factory.build(is_private=False)
 
-        mutation = mutation_generator.create_topic(title=topic.title, description=topic.description,
-                                                   is_private=str(topic.is_private).lower(), original_poster_id=user.id,
-                                                   group_id=group.id)
+        mutation = MutationGenerator.create_topic(title=topic.title, description=topic.description,
+                                                  is_private=str(topic.is_private).lower(), original_poster_id=user.id,
+                                                  group_id=group.id)
         response = client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createTopic'] is None
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_valid(self, auth_client, mutation_generator, topic_factory, user_factory, group_factory):
+    def test_valid(self, auth_client, topic_factory, user_factory, group_factory):
         group = group_factory()
         user = user_factory()
         topic = topic_factory.build(is_private=False)
 
-        mutation = mutation_generator.create_topic(title=topic.title, description=topic.description,
-                                                   is_private=str(topic.is_private).lower(), original_poster_id=user.id,
-                                                   group_id=group.id)
+        mutation = MutationGenerator.create_topic(title=topic.title, description=topic.description,
+                                                  is_private=str(topic.is_private).lower(), original_poster_id=user.id,
+                                                  group_id=group.id)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createTopic']['topic']['title'] == topic.title
 
     @pytest.mark.django_db
-    def test_valid_and_create_tags(self, auth_client, mutation_generator, topic_factory, user_factory, group_factory,
+    def test_valid_and_create_tags(self, auth_client, topic_factory, user_factory, group_factory,
                                    tag_factory):
         group = group_factory()
         user = user_factory()
@@ -41,11 +43,11 @@ class TestCreateTopic:
         tag_one = tag_factory.build()
         tag_two = tag_factory.build()
 
-        mutation = mutation_generator.create_topic(title=topic.title, description=topic.description,
-                                                   is_private=str(topic.is_private).lower(), original_poster_id=user.id,
-                                                   group_id=group.id, tags=[tag_one, tag_two])
+        mutation = MutationGenerator.create_topic(title=topic.title, description=topic.description,
+                                                  is_private=str(topic.is_private).lower(), original_poster_id=user.id,
+                                                  group_id=group.id, tags=[tag_one, tag_two])
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createTopic']['topic']
         assert len(response.json()['data']['createTopic']['topic']['tags']) == 2

--- a/tests/func/topics/test_mark_discussion_as_pending_closed.py
+++ b/tests/func/topics/test_mark_discussion_as_pending_closed.py
@@ -1,48 +1,50 @@
 import pytest
 
+from tests.resources.MutationGenerator import MutationGenerator
+
 
 class TestMarkDiscussionAsPendingClosed:
 
     @pytest.mark.django_db
-    def test_unauthenticated(self, client, mutation_generator, discussion_factory):
+    def test_unauthenticated(self, client, discussion_factory):
         discussion = discussion_factory(topic__is_private=False, status='STALE')
 
-        mutation = mutation_generator.mark_discussion_as_pending_closed(discussion.id)
+        mutation = MutationGenerator.mark_discussion_as_pending_closed(discussion.id)
         response = client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['markDiscussionAsPendingClosed'] is None
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_invalid_discussion(self, auth_client, mutation_generator):
-        mutation = mutation_generator.mark_discussion_as_pending_closed(1)
+    def test_invalid_discussion(self, auth_client):
+        mutation = MutationGenerator.mark_discussion_as_pending_closed(1)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['markDiscussionAsPendingClosed'] is None
         assert response.json()['errors'][0]['message'] == 'Discussion matching query does not exist.'
 
     @pytest.mark.django_db
-    def test_invalid_discussion_state(self, auth_client, mutation_generator, discussion_factory):
+    def test_invalid_discussion_state(self, auth_client, discussion_factory):
         discussion = discussion_factory(topic__is_private=False, status='OPEN')
 
-        mutation = mutation_generator.mark_discussion_as_pending_closed(discussion.id)
+        mutation = MutationGenerator.mark_discussion_as_pending_closed(discussion.id)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['markDiscussionAsPendingClosed'] is None
         assert response.json()['errors'][0]['message'] == "Can't switch from state 'OPEN' using method " \
                                                           "'mark_as_pending_closed'"
 
     @pytest.mark.django_db
     @pytest.mark.usefixtures('auto_close_pending_closed_discussion_task', 'slack_app_request')
-    def test_valid(self, auth_client, mutation_generator, discussion_factory):
+    def test_valid(self, auth_client, discussion_factory):
         discussion = discussion_factory(topic__is_private=False, status='STALE')
 
-        mutation = mutation_generator.mark_discussion_as_pending_closed(discussion.id)
+        mutation = MutationGenerator.mark_discussion_as_pending_closed(discussion.id)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['markDiscussionAsPendingClosed']['discussion'][
                    'status'] == 'PENDING CLOSED'

--- a/tests/func/topics/test_mark_discussion_as_pending_closed.py
+++ b/tests/func/topics/test_mark_discussion_as_pending_closed.py
@@ -61,8 +61,8 @@ class TestMarkDiscussionAsPendingClosed:
                                                           "'mark_as_pending_closed'"
 
     @pytest.mark.django_db
-    def test_valid(self, auth_client, discussion_factory, auto_close_pending_closed_discussion_factory,
-                   slack_app_request_factory):
+    @pytest.mark.usefixtures('auto_close_pending_closed_discussion_task', 'slack_app_request')
+    def test_valid(self, auth_client, discussion_factory):
         discussion = discussion_factory(topic__is_private=False, status='STALE')
 
         mutation = f'''

--- a/tests/func/topics/test_monitoring_discussions.py
+++ b/tests/func/topics/test_monitoring_discussions.py
@@ -7,6 +7,7 @@ from django.conf import settings
 
 from app.topics.models import Discussion
 from tests.utils import wait_until
+from tests.resources.MutationGenerator import MutationGenerator
 
 
 class TestMarkingDiscussionAsStale:
@@ -27,7 +28,7 @@ class TestMarkingDiscussionAsStale:
     @pytest.mark.django_db(transaction=True)
     @pytest.mark.usefixture('use_slack_domain')
     def test_does_not_become_stale_with_non_bot_message(self, mark_stale_discussion_task, auth_client,
-                                                        mutation_generator, discussion_factory, slack_channel_factory,
+                                                        discussion_factory, slack_channel_factory,
                                                         message_factory, user_factory, slack_user_factory,
                                                         slack_event_factory, slack_app_request):
         mark_stale_discussion_task(num_periods=3, period_length=1.5)
@@ -40,12 +41,12 @@ class TestMarkingDiscussionAsStale:
         slack_event = slack_event_factory.build(ts=(original_time + timedelta(minutes=2)).timestamp())
         message = message_factory.build()
 
-        mutation = mutation_generator.create_message_from_slack(text=message.text,
-                                                                slack_channel_id=slack_channel.id,
-                                                                slack_user_id=slack_user.id,
-                                                                origin_slack_event_ts=slack_event.ts)
+        mutation = MutationGenerator.create_message_from_slack(text=message.text,
+                                                               slack_channel_id=slack_channel.id,
+                                                               slack_user_id=slack_user.id,
+                                                               origin_slack_event_ts=slack_event.ts)
         response = auth_client.post('/graphql', {'query': mutation})
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
 
         wait_until(condition=lambda: Discussion.objects.get(pk=discussion.id).is_stale, timeout=5)
 
@@ -55,7 +56,7 @@ class TestMarkingDiscussionAsStale:
     @pytest.mark.django_db(transaction=True)
     @pytest.mark.usefixtures('use_slack_domain')
     def test_does_become_stale_with_bot_message(self, mark_stale_discussion_task, auth_client, discussion_factory,
-                                                mutation_generator, slack_channel_factory, message_factory,
+                                                slack_channel_factory, message_factory,
                                                 user_factory, slack_user_factory, slack_event_factory,
                                                 slack_app_request):
         mark_stale_discussion_task(num_periods=3, period_length=1.5)
@@ -68,12 +69,12 @@ class TestMarkingDiscussionAsStale:
         slack_event = slack_event_factory.build(ts=(original_time + timedelta(minutes=2)).timestamp())
         message = message_factory.build()
 
-        mutation = mutation_generator.create_message_from_slack(text=message.text,
-                                                                slack_channel_id=slack_channel.id,
-                                                                slack_user_id=slack_user.id,
-                                                                origin_slack_event_ts=slack_event.ts)
+        mutation = MutationGenerator.create_message_from_slack(text=message.text,
+                                                               slack_channel_id=slack_channel.id,
+                                                               slack_user_id=slack_user.id,
+                                                               origin_slack_event_ts=slack_event.ts)
         response = auth_client.post('/graphql', {'query': mutation})
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
 
         wait_until(condition=lambda: len(slack_app_request.calls) == 1, timeout=5)
         discussion = Discussion.objects.get(pk=discussion.id)
@@ -89,7 +90,7 @@ class TestMarkingDiscussionAsStale:
 class TestClosingPendingClosedDiscussion:
     @pytest.mark.django_db(transaction=True)
     @pytest.mark.usefixtures('use_slack_domain', 'auto_close_pending_closed_discussion_task')
-    def test_does_get_closed(self, auth_client, mutation_generator, discussion_factory, slack_channel_factory,
+    def test_does_get_closed(self, auth_client, discussion_factory, slack_channel_factory,
                              message_factory, user_factory, slack_user_factory, slack_event_factory, slack_app_request):
         original_time = datetime.now(tz=pytz.UTC) - timedelta(minutes=31)
         discussion = discussion_factory(topic__is_private=False, time_start=original_time)
@@ -101,19 +102,19 @@ class TestClosingPendingClosedDiscussion:
         slack_event = slack_event_factory(ts=(original_time + timedelta(seconds=30)).timestamp())
         message = message_factory.build(time=original_time + timedelta(seconds=30), discussion=discussion)
 
-        mutation = mutation_generator.create_message_from_slack(text=message.text,
-                                                                slack_channel_id=slack_channel.id,
-                                                                slack_user_id=non_bot_slack_user.id,
-                                                                origin_slack_event_ts=slack_event.ts)
+        mutation = MutationGenerator.create_message_from_slack(text=message.text,
+                                                               slack_channel_id=slack_channel.id,
+                                                               slack_user_id=non_bot_slack_user.id,
+                                                               origin_slack_event_ts=slack_event.ts)
         response = auth_client.post('/graphql', {'query': mutation})
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
 
         discussion.mark_as_stale()
         discussion.save()
 
-        mutation = mutation_generator.mark_discussion_as_pending_closed_from_slack(slack_channel_id=slack_channel.id)
+        mutation = MutationGenerator.mark_discussion_as_pending_closed_from_slack(slack_channel_id=slack_channel.id)
         response = auth_client.post('/graphql', {'query': mutation})
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert not Discussion.objects.get(pk=discussion.id).is_closed
 
         wait_until(condition=lambda: len(slack_app_request.calls) == 1, timeout=5)
@@ -127,7 +128,7 @@ class TestClosingPendingClosedDiscussion:
 
     @pytest.mark.django_db
     @pytest.mark.usefixtures('use_slack_domain', 'auto_close_pending_closed_discussion_task')
-    def test_does_not_get_closed_with_non_bot_message(self, auth_client, mutation_generator, discussion_factory,
+    def test_does_not_get_closed_with_non_bot_message(self, auth_client, discussion_factory,
                                                       slack_channel_factory, message_factory, user_factory,
                                                       slack_user_factory, slack_event_factory, slack_app_request):
         original_time = datetime.now(tz=pytz.UTC) - timedelta(minutes=31)
@@ -139,33 +140,33 @@ class TestClosingPendingClosedDiscussion:
         message = message_factory.build(time=original_time + timedelta(seconds=30), discussion=discussion)
 
         # Old message sent
-        mutation = mutation_generator.create_message_from_slack(text=message.text,
-                                                                slack_channel_id=slack_channel.id,
-                                                                slack_user_id=non_bot_slack_user.id,
-                                                                origin_slack_event_ts=slack_event.ts)
+        mutation = MutationGenerator.create_message_from_slack(text=message.text,
+                                                               slack_channel_id=slack_channel.id,
+                                                               slack_user_id=non_bot_slack_user.id,
+                                                               origin_slack_event_ts=slack_event.ts)
         response = auth_client.post('/graphql', {'query': mutation})
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
 
         # Discussion marked as stale
         discussion.mark_as_stale()
         discussion.save()
 
         # Discussion marked as pending closed
-        mutation = mutation_generator.mark_discussion_as_pending_closed_from_slack(slack_channel_id=slack_channel.id)
+        mutation = MutationGenerator.mark_discussion_as_pending_closed_from_slack(slack_channel_id=slack_channel.id)
         response = auth_client.post('/graphql', {'query': mutation})
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert not Discussion.objects.get(pk=discussion.id).is_closed
 
         # New message sent
         slack_event = slack_event_factory(ts=datetime.utcnow().timestamp())
         message = message_factory.build(discussion=discussion, author=non_bot_user)
 
-        mutation = mutation_generator.create_message_from_slack(text=message.text,
-                                                                slack_channel_id=slack_channel.id,
-                                                                slack_user_id=non_bot_slack_user.id,
-                                                                origin_slack_event_ts=slack_event.ts)
+        mutation = MutationGenerator.create_message_from_slack(text=message.text,
+                                                               slack_channel_id=slack_channel.id,
+                                                               slack_user_id=non_bot_slack_user.id,
+                                                               origin_slack_event_ts=slack_event.ts)
         response = auth_client.post('/graphql', {'query': mutation})
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
 
         wait_until(condition=lambda: Discussion.objects.get(pk=discussion.id).is_closed, timeout=5)
 
@@ -174,7 +175,7 @@ class TestClosingPendingClosedDiscussion:
 
     @pytest.mark.django_db
     @pytest.mark.usefixtures('use_slack_domain', 'auto_close_pending_closed_discussion_task')
-    def test_does_get_closed_with_bot_message(self, auth_client, mutation_generator, discussion_factory,
+    def test_does_get_closed_with_bot_message(self, auth_client, discussion_factory,
                                               slack_channel_factory, message_factory, user_factory, slack_user_factory,
                                               slack_event_factory, slack_app_request):
         original_time = datetime.now(tz=pytz.UTC) - timedelta(minutes=31)
@@ -188,20 +189,20 @@ class TestClosingPendingClosedDiscussion:
         message = message_factory.build(time=original_time + timedelta(seconds=30), discussion=discussion)
 
         # Old message sent
-        mutation = mutation_generator.create_message_from_slack(text=message.text, slack_channel_id=slack_channel.id,
-                                                                slack_user_id=non_bot_slack_user.id,
-                                                                origin_slack_event_ts=slack_event.ts)
+        mutation = MutationGenerator.create_message_from_slack(text=message.text, slack_channel_id=slack_channel.id,
+                                                               slack_user_id=non_bot_slack_user.id,
+                                                               origin_slack_event_ts=slack_event.ts)
         response = auth_client.post('/graphql', {'query': mutation})
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
 
         # Discussion marked as stale
         discussion.mark_as_stale()
         discussion.save()
 
         # Discussion marked as pending closed
-        mutation = mutation_generator.mark_discussion_as_pending_closed_from_slack(slack_channel_id=slack_channel.id)
+        mutation = MutationGenerator.mark_discussion_as_pending_closed_from_slack(slack_channel_id=slack_channel.id)
         response = auth_client.post('/graphql', {'query': mutation})
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert not Discussion.objects.get(pk=discussion.id).is_closed
         assert not slack_app_request.calls
 
@@ -209,11 +210,11 @@ class TestClosingPendingClosedDiscussion:
         slack_event = slack_event_factory(ts=datetime.now(pytz.UTC).timestamp())
         message = message_factory.build(discussion=discussion, author=bot_user)
 
-        mutation = mutation_generator.create_message_from_slack(text=message.text, slack_channel_id=slack_channel.id,
-                                                                slack_user_id=bot_slack_user.id,
-                                                                origin_slack_event_ts=slack_event.ts)
+        mutation = MutationGenerator.create_message_from_slack(text=message.text, slack_channel_id=slack_channel.id,
+                                                               slack_user_id=bot_slack_user.id,
+                                                               origin_slack_event_ts=slack_event.ts)
         response = auth_client.post('/graphql', {'query': mutation})
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
 
         wait_until(condition=lambda: len(slack_app_request.calls) == 1, timeout=5)
         discussion = Discussion.objects.get(pk=discussion.id)
@@ -227,7 +228,7 @@ class TestClosingPendingClosedDiscussion:
 
     @pytest.mark.django_db
     @pytest.mark.usefixtures('use_slack_domain', 'auto_close_pending_closed_discussion_task')
-    def test_does_get_closed_with_no_messages_ever(self, auth_client, mutation_generator, discussion_factory,
+    def test_does_get_closed_with_no_messages_ever(self, auth_client, discussion_factory,
                                                    slack_channel_factory, slack_app_request):
         original_time = datetime.now(tz=pytz.UTC) - timedelta(minutes=31)
         discussion = discussion_factory(topic__is_private=False, time_start=original_time)
@@ -236,9 +237,9 @@ class TestClosingPendingClosedDiscussion:
         discussion.mark_as_stale()
         discussion.save()
 
-        mutation = mutation_generator.mark_discussion_as_pending_closed_from_slack(slack_channel_id=slack_channel.id)
+        mutation = MutationGenerator.mark_discussion_as_pending_closed_from_slack(slack_channel_id=slack_channel.id)
         response = auth_client.post('/graphql', {'query': mutation})
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
 
         wait_until(condition=lambda: len(slack_app_request.calls) == 1, timeout=5)
         discussion = Discussion.objects.get(pk=discussion.id)

--- a/tests/func/topics/test_monitoring_discussions.py
+++ b/tests/func/topics/test_monitoring_discussions.py
@@ -27,9 +27,9 @@ class TestMarkingDiscussionAsStale:
     @pytest.mark.django_db(transaction=True)
     @pytest.mark.usefixture('use_slack_domain')
     def test_does_not_become_stale_with_non_bot_message(self, mark_stale_discussion_task, auth_client,
-                                                        discussion_factory, slack_channel_factory, message_factory,
-                                                        user_factory, slack_user_factory, slack_event_factory,
-                                                        slack_app_request):
+                                                        mutation_generator, discussion_factory, slack_channel_factory,
+                                                        message_factory, user_factory, slack_user_factory,
+                                                        slack_event_factory, slack_app_request):
         mark_stale_discussion_task(num_periods=3, period_length=1.5)
 
         original_time = datetime.now(tz=pytz.UTC) - timedelta(minutes=29, seconds=58)
@@ -40,16 +40,10 @@ class TestMarkingDiscussionAsStale:
         slack_event = slack_event_factory.build(ts=(original_time + timedelta(minutes=2)).timestamp())
         message = message_factory.build()
 
-        mutation = f'''
-          mutation {{
-            createMessageFromSlack(input: {{text: "{message.text}", slackChannelId: "{slack_channel.id}",
-                                            slackUserId: "{slack_user.id}", originSlackEventTs: "{slack_event.ts}"}}) {{
-              message {{
-                text
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_message_from_slack(text=message.text,
+                                                                slack_channel_id=slack_channel.id,
+                                                                slack_user_id=slack_user.id,
+                                                                origin_slack_event_ts=slack_event.ts)
         response = auth_client.post('/graphql', {'query': mutation})
         assert response.status_code == 200
 
@@ -61,8 +55,9 @@ class TestMarkingDiscussionAsStale:
     @pytest.mark.django_db(transaction=True)
     @pytest.mark.usefixtures('use_slack_domain')
     def test_does_become_stale_with_bot_message(self, mark_stale_discussion_task, auth_client, discussion_factory,
-                                                slack_channel_factory, message_factory, user_factory,
-                                                slack_user_factory, slack_event_factory, slack_app_request):
+                                                mutation_generator, slack_channel_factory, message_factory,
+                                                user_factory, slack_user_factory, slack_event_factory,
+                                                slack_app_request):
         mark_stale_discussion_task(num_periods=3, period_length=1.5)
 
         original_time = datetime.now(tz=pytz.UTC) - timedelta(minutes=29, seconds=57)
@@ -73,16 +68,10 @@ class TestMarkingDiscussionAsStale:
         slack_event = slack_event_factory.build(ts=(original_time + timedelta(minutes=2)).timestamp())
         message = message_factory.build()
 
-        mutation = f'''
-          mutation {{
-            createMessageFromSlack(input: {{text: "{message.text}", slackChannelId: "{slack_channel.id}",
-                                            slackUserId: "{slack_user.id}", originSlackEventTs: "{slack_event.ts}"}}) {{
-              message {{
-                text
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_message_from_slack(text=message.text,
+                                                                slack_channel_id=slack_channel.id,
+                                                                slack_user_id=slack_user.id,
+                                                                origin_slack_event_ts=slack_event.ts)
         response = auth_client.post('/graphql', {'query': mutation})
         assert response.status_code == 200
 
@@ -100,8 +89,8 @@ class TestMarkingDiscussionAsStale:
 class TestClosingPendingClosedDiscussion:
     @pytest.mark.django_db(transaction=True)
     @pytest.mark.usefixtures('use_slack_domain', 'auto_close_pending_closed_discussion_task')
-    def test_does_get_closed(self, auth_client, discussion_factory, slack_channel_factory, message_factory,
-                             user_factory, slack_user_factory, slack_event_factory, slack_app_request):
+    def test_does_get_closed(self, auth_client, mutation_generator, discussion_factory, slack_channel_factory,
+                             message_factory, user_factory, slack_user_factory, slack_event_factory, slack_app_request):
         original_time = datetime.now(tz=pytz.UTC) - timedelta(minutes=31)
         discussion = discussion_factory(topic__is_private=False, time_start=original_time)
         slack_channel = slack_channel_factory(discussion=discussion)
@@ -112,30 +101,17 @@ class TestClosingPendingClosedDiscussion:
         slack_event = slack_event_factory(ts=(original_time + timedelta(seconds=30)).timestamp())
         message = message_factory.build(time=original_time + timedelta(seconds=30), discussion=discussion)
 
-        mutation = f'''
-          mutation {{
-            createMessageFromSlack(input: {{text: "{message.text}", slackChannelId: "{slack_channel.id}",
-                                            slackUserId: "{non_bot_slack_user.id}",
-                                            originSlackEventTs: "{slack_event.ts}"}}) {{
-              message {{ id }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_message_from_slack(text=message.text,
+                                                                slack_channel_id=slack_channel.id,
+                                                                slack_user_id=non_bot_slack_user.id,
+                                                                origin_slack_event_ts=slack_event.ts)
         response = auth_client.post('/graphql', {'query': mutation})
         assert response.status_code == 200
 
         discussion.mark_as_stale()
         discussion.save()
 
-        mutation = f'''
-          mutation {{
-            markDiscussionAsPendingClosedFromSlack(input: {{slackChannelId: "{slack_channel.id}"}}) {{
-              discussion {{
-                status
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.mark_discussion_as_pending_closed_from_slack(slack_channel_id=slack_channel.id)
         response = auth_client.post('/graphql', {'query': mutation})
         assert response.status_code == 200
         assert not Discussion.objects.get(pk=discussion.id).is_closed
@@ -151,9 +127,9 @@ class TestClosingPendingClosedDiscussion:
 
     @pytest.mark.django_db
     @pytest.mark.usefixtures('use_slack_domain', 'auto_close_pending_closed_discussion_task')
-    def test_does_not_get_closed_with_non_bot_message(self, auth_client, discussion_factory, slack_channel_factory,
-                                                      message_factory, user_factory, slack_user_factory,
-                                                      slack_event_factory, slack_app_request):
+    def test_does_not_get_closed_with_non_bot_message(self, auth_client, mutation_generator, discussion_factory,
+                                                      slack_channel_factory, message_factory, user_factory,
+                                                      slack_user_factory, slack_event_factory, slack_app_request):
         original_time = datetime.now(tz=pytz.UTC) - timedelta(minutes=31)
         discussion = discussion_factory(topic__is_private=False, time_start=original_time)
         slack_channel = slack_channel_factory(discussion=discussion)
@@ -163,15 +139,10 @@ class TestClosingPendingClosedDiscussion:
         message = message_factory.build(time=original_time + timedelta(seconds=30), discussion=discussion)
 
         # Old message sent
-        mutation = f'''
-          mutation {{
-            createMessageFromSlack(input: {{text: "{message.text}", slackChannelId: "{slack_channel.id}",
-                                            slackUserId: "{non_bot_slack_user.id}",
-                                            originSlackEventTs: "{slack_event.ts}"}}) {{
-              message {{ id }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_message_from_slack(text=message.text,
+                                                                slack_channel_id=slack_channel.id,
+                                                                slack_user_id=non_bot_slack_user.id,
+                                                                origin_slack_event_ts=slack_event.ts)
         response = auth_client.post('/graphql', {'query': mutation})
         assert response.status_code == 200
 
@@ -180,15 +151,7 @@ class TestClosingPendingClosedDiscussion:
         discussion.save()
 
         # Discussion marked as pending closed
-        mutation = f'''
-          mutation {{
-            markDiscussionAsPendingClosedFromSlack(input: {{slackChannelId: "{slack_channel.id}"}}) {{
-              discussion {{
-                status
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.mark_discussion_as_pending_closed_from_slack(slack_channel_id=slack_channel.id)
         response = auth_client.post('/graphql', {'query': mutation})
         assert response.status_code == 200
         assert not Discussion.objects.get(pk=discussion.id).is_closed
@@ -197,15 +160,10 @@ class TestClosingPendingClosedDiscussion:
         slack_event = slack_event_factory(ts=datetime.utcnow().timestamp())
         message = message_factory.build(discussion=discussion, author=non_bot_user)
 
-        mutation = f'''
-          mutation {{
-            createMessageFromSlack(input: {{text: "{message.text}", slackChannelId: "{slack_channel.id}",
-                                            slackUserId: "{non_bot_slack_user.id}",
-                                            originSlackEventTs: "{slack_event.ts}"}}) {{
-              message {{ id }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_message_from_slack(text=message.text,
+                                                                slack_channel_id=slack_channel.id,
+                                                                slack_user_id=non_bot_slack_user.id,
+                                                                origin_slack_event_ts=slack_event.ts)
         response = auth_client.post('/graphql', {'query': mutation})
         assert response.status_code == 200
 
@@ -216,8 +174,8 @@ class TestClosingPendingClosedDiscussion:
 
     @pytest.mark.django_db
     @pytest.mark.usefixtures('use_slack_domain', 'auto_close_pending_closed_discussion_task')
-    def test_does_get_closed_with_bot_message(self, auth_client, discussion_factory, slack_channel_factory,
-                                              message_factory, user_factory, slack_user_factory,
+    def test_does_get_closed_with_bot_message(self, auth_client, mutation_generator, discussion_factory,
+                                              slack_channel_factory, message_factory, user_factory, slack_user_factory,
                                               slack_event_factory, slack_app_request):
         original_time = datetime.now(tz=pytz.UTC) - timedelta(minutes=31)
         discussion = discussion_factory(topic__is_private=False, time_start=original_time)
@@ -230,15 +188,9 @@ class TestClosingPendingClosedDiscussion:
         message = message_factory.build(time=original_time + timedelta(seconds=30), discussion=discussion)
 
         # Old message sent
-        mutation = f'''
-          mutation {{
-            createMessageFromSlack(input: {{text: "{message.text}", slackChannelId: "{slack_channel.id}",
-                                            slackUserId: "{non_bot_slack_user.id}",
-                                            originSlackEventTs: "{slack_event.ts}"}}) {{
-              message {{ id }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_message_from_slack(text=message.text, slack_channel_id=slack_channel.id,
+                                                                slack_user_id=non_bot_slack_user.id,
+                                                                origin_slack_event_ts=slack_event.ts)
         response = auth_client.post('/graphql', {'query': mutation})
         assert response.status_code == 200
 
@@ -247,15 +199,7 @@ class TestClosingPendingClosedDiscussion:
         discussion.save()
 
         # Discussion marked as pending closed
-        mutation = f'''
-          mutation {{
-            markDiscussionAsPendingClosedFromSlack(input: {{slackChannelId: "{slack_channel.id}"}}) {{
-              discussion {{
-                status
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.mark_discussion_as_pending_closed_from_slack(slack_channel_id=slack_channel.id)
         response = auth_client.post('/graphql', {'query': mutation})
         assert response.status_code == 200
         assert not Discussion.objects.get(pk=discussion.id).is_closed
@@ -265,15 +209,9 @@ class TestClosingPendingClosedDiscussion:
         slack_event = slack_event_factory(ts=datetime.now(pytz.UTC).timestamp())
         message = message_factory.build(discussion=discussion, author=bot_user)
 
-        mutation = f'''
-          mutation {{
-            createMessageFromSlack(input: {{text: "{message.text}", slackChannelId: "{slack_channel.id}",
-                                            slackUserId: "{bot_slack_user.id}",
-                                            originSlackEventTs: "{slack_event.ts}"}}) {{
-              message {{ id }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_message_from_slack(text=message.text, slack_channel_id=slack_channel.id,
+                                                                slack_user_id=bot_slack_user.id,
+                                                                origin_slack_event_ts=slack_event.ts)
         response = auth_client.post('/graphql', {'query': mutation})
         assert response.status_code == 200
 
@@ -289,8 +227,8 @@ class TestClosingPendingClosedDiscussion:
 
     @pytest.mark.django_db
     @pytest.mark.usefixtures('use_slack_domain', 'auto_close_pending_closed_discussion_task')
-    def test_does_get_closed_with_no_messages_ever(self, auth_client, discussion_factory, slack_channel_factory,
-                                                   slack_app_request):
+    def test_does_get_closed_with_no_messages_ever(self, auth_client, mutation_generator, discussion_factory,
+                                                   slack_channel_factory, slack_app_request):
         original_time = datetime.now(tz=pytz.UTC) - timedelta(minutes=31)
         discussion = discussion_factory(topic__is_private=False, time_start=original_time)
         slack_channel = slack_channel_factory(discussion=discussion)
@@ -298,15 +236,7 @@ class TestClosingPendingClosedDiscussion:
         discussion.mark_as_stale()
         discussion.save()
 
-        mutation = f'''
-          mutation {{
-            markDiscussionAsPendingClosedFromSlack(input: {{slackChannelId: "{slack_channel.id}"}}) {{
-              discussion {{
-                status
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.mark_discussion_as_pending_closed_from_slack(slack_channel_id=slack_channel.id)
         response = auth_client.post('/graphql', {'query': mutation})
         assert response.status_code == 200
 

--- a/tests/func/topics/test_query_discussions.py
+++ b/tests/func/topics/test_query_discussions.py
@@ -1,48 +1,50 @@
 import pytest
 
+from tests.resources.QueryGenerator import QueryGenerator
+
 
 class TestQueryDiscussions:
 
     @pytest.mark.django_db
-    def test_get_discussion(self, client, query_generator, discussion_factory):
+    def test_get_discussion(self, client, discussion_factory):
         discussion = discussion_factory(topic__is_private=False)
 
-        query = query_generator.get_discussion(discussion.id)
+        query = QueryGenerator.get_discussion(discussion.id)
         response = client.post('/graphql', {'query': query})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['discussion']['topic']['title'] == discussion.topic.title
 
     @pytest.mark.django_db
-    def test_get_discussion_private_topic(self, client, query_generator, discussion_factory):
+    def test_get_discussion_private_topic(self, client, discussion_factory):
         discussion = discussion_factory(topic__is_private=True)
 
-        query = query_generator.get_discussion(discussion.id)
+        query = QueryGenerator.get_discussion(discussion.id)
         response = client.post('/graphql', {'query': query})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['discussion'] is None
 
     @pytest.mark.django_db
-    def test_get_discussions(self, client, query_generator, discussion_factory):
+    def test_get_discussions(self, client, discussion_factory):
         discussion_factory(topic__is_private=False)
         discussion_factory(topic__is_private=False)
 
-        query = query_generator.get_discussions()
+        query = QueryGenerator.get_discussions()
         response = client.post('/graphql', {'query': query})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert len(response.json()['data']['discussions']) == 2
         assert response.json()['data']['discussions'][0]
 
     @pytest.mark.django_db
-    def test_get_discussions_private_topic(self, client, query_generator, discussion_factory):
+    def test_get_discussions_private_topic(self, client, discussion_factory):
         discussion_factory(topic__is_private=True)
         discussion_factory(topic__is_private=True)
 
-        query = query_generator.get_discussions()
+        query = QueryGenerator.get_discussions()
         response = client.post('/graphql', {'query': query})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert len(response.json()['data']['discussions']) == 2
         assert response.json()['data']['discussions'][0] is None

--- a/tests/func/topics/test_query_discussions.py
+++ b/tests/func/topics/test_query_discussions.py
@@ -4,44 +4,44 @@ import pytest
 class TestQueryDiscussions:
 
     @pytest.mark.django_db
-    def test_get_discussion(self, discussion_factory, client):
+    def test_get_discussion(self, client, query_generator, discussion_factory):
         discussion = discussion_factory(topic__is_private=False)
 
-        query = {'query': f'{{ discussion(id: {discussion.id}) {{ topic {{ title }} }} }}'}
-        response = client.post('/graphql', query)
+        query = query_generator.get_discussion(discussion.id)
+        response = client.post('/graphql', {'query': query})
 
         assert response.status_code == 200
         assert response.json()['data']['discussion']['topic']['title'] == discussion.topic.title
 
     @pytest.mark.django_db
-    def test_get_discussion_private_topic(self, discussion_factory, client):
+    def test_get_discussion_private_topic(self, client, query_generator, discussion_factory):
         discussion = discussion_factory(topic__is_private=True)
 
-        query = {'query': f'{{ discussion(id: {discussion.id}) {{ topic {{ title }} }} }}'}
-        response = client.post('/graphql', query)
+        query = query_generator.get_discussion(discussion.id)
+        response = client.post('/graphql', {'query': query})
 
         assert response.status_code == 200
         assert response.json()['data']['discussion'] is None
 
     @pytest.mark.django_db
-    def test_get_discussions(self, discussion_factory, client):
+    def test_get_discussions(self, client, query_generator, discussion_factory):
         discussion_factory(topic__is_private=False)
         discussion_factory(topic__is_private=False)
 
-        query = {'query': '{ discussions { id } }'}
-        response = client.post('/graphql', query)
+        query = query_generator.get_discussions()
+        response = client.post('/graphql', {'query': query})
 
         assert response.status_code == 200
         assert len(response.json()['data']['discussions']) == 2
         assert response.json()['data']['discussions'][0]
 
     @pytest.mark.django_db
-    def test_get_discussions_private_topic(self, discussion_factory, client):
+    def test_get_discussions_private_topic(self, client, query_generator, discussion_factory):
         discussion_factory(topic__is_private=True)
         discussion_factory(topic__is_private=True)
 
-        query = {'query': '{ discussions { id } }'}
-        response = client.post('/graphql', query)
+        query = query_generator.get_discussions()
+        response = client.post('/graphql', {'query': query})
 
         assert response.status_code == 200
         assert len(response.json()['data']['discussions']) == 2

--- a/tests/func/topics/test_query_tags.py
+++ b/tests/func/topics/test_query_tags.py
@@ -4,22 +4,22 @@ import pytest
 class TestQueryTags:
 
     @pytest.mark.django_db
-    def test_get_tag(self, tag_factory, client):
+    def test_get_tag(self, client, query_generator, tag_factory):
         tag = tag_factory()
 
-        query = {'query': f'{{ tag(name: "{tag.name}") {{ id }} }}'}
-        response = client.post('/graphql', query)
+        query = query_generator.get_tag(tag.name)
+        response = client.post('/graphql', {'query': query})
 
         assert response.status_code == 200
         assert response.json()['data']['tag']['id'] == str(tag.id)
 
     @pytest.mark.django_db
-    def test_get_tags(self, tag_factory, client):
+    def test_get_tags(self, client, query_generator, tag_factory):
         tag_factory()
         tag_factory()
 
-        query = {'query': '{ tags { name } }'}
-        response = client.post('/graphql', query)
+        query = query_generator.get_tags()
+        response = client.post('/graphql', {'query': query})
 
         assert response.status_code == 200
         assert len(response.json()['data']['tags']) == 2

--- a/tests/func/topics/test_query_tags.py
+++ b/tests/func/topics/test_query_tags.py
@@ -1,25 +1,27 @@
 import pytest
 
+from tests.resources.QueryGenerator import QueryGenerator
+
 
 class TestQueryTags:
 
     @pytest.mark.django_db
-    def test_get_tag(self, client, query_generator, tag_factory):
+    def test_get_tag(self, client, tag_factory):
         tag = tag_factory()
 
-        query = query_generator.get_tag(tag.name)
+        query = QueryGenerator.get_tag(tag.name)
         response = client.post('/graphql', {'query': query})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['tag']['id'] == str(tag.id)
 
     @pytest.mark.django_db
-    def test_get_tags(self, client, query_generator, tag_factory):
+    def test_get_tags(self, client, tag_factory):
         tag_factory()
         tag_factory()
 
-        query = query_generator.get_tags()
+        query = QueryGenerator.get_tags()
         response = client.post('/graphql', {'query': query})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert len(response.json()['data']['tags']) == 2

--- a/tests/func/topics/test_query_topics.py
+++ b/tests/func/topics/test_query_topics.py
@@ -1,48 +1,50 @@
 import pytest
 
+from tests.resources.QueryGenerator import QueryGenerator
+
 
 class TestQueryTopics:
 
     @pytest.mark.django_db
-    def test_get_topic(self, client, query_generator, topic_factory):
+    def test_get_topic(self, client, topic_factory):
         topic = topic_factory(is_private=False)
 
-        query = query_generator.get_topic(topic.id)
+        query = QueryGenerator.get_topic(topic.id)
         response = client.post('/graphql', {'query': query})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['topic']['title'] == topic.title
 
     @pytest.mark.django_db
-    def test_get_private_topic(self, client, query_generator, topic_factory):
+    def test_get_private_topic(self, client, topic_factory):
         topic = topic_factory(is_private=True)
 
-        query = query_generator.get_topic(topic.id)
+        query = QueryGenerator.get_topic(topic.id)
         response = client.post('/graphql', {'query': query})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['topic'] is None
 
     @pytest.mark.django_db
-    def test_get_topics(self, client, query_generator, topic_factory):
+    def test_get_topics(self, client, topic_factory):
         topic_factory(is_private=False)
         topic_factory(is_private=False)
 
-        query = query_generator.get_topics()
+        query = QueryGenerator.get_topics()
         response = client.post('/graphql', {'query': query})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert len(response.json()['data']['topics']) == 2
         assert response.json()['data']['topics'][0]
 
     @pytest.mark.django_db
-    def test_get_private_topics(self, client, query_generator, topic_factory):
+    def test_get_private_topics(self, client, topic_factory):
         topic_factory(is_private=True)
         topic_factory(is_private=True)
 
-        query = query_generator.get_topics()
+        query = QueryGenerator.get_topics()
         response = client.post('/graphql', {'query': query})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert len(response.json()['data']['topics']) == 2
         assert response.json()['data']['topics'][0] is None

--- a/tests/func/topics/test_query_topics.py
+++ b/tests/func/topics/test_query_topics.py
@@ -4,44 +4,44 @@ import pytest
 class TestQueryTopics:
 
     @pytest.mark.django_db
-    def test_get_topic(self, topic_factory, client):
+    def test_get_topic(self, client, query_generator, topic_factory):
         topic = topic_factory(is_private=False)
 
-        query = {'query': f'{{ topic(id: {topic.id}) {{ title }} }}'}
-        response = client.post('/graphql', query)
+        query = query_generator.get_topic(topic.id)
+        response = client.post('/graphql', {'query': query})
 
         assert response.status_code == 200
         assert response.json()['data']['topic']['title'] == topic.title
 
     @pytest.mark.django_db
-    def test_get_private_topic(self, topic_factory, client):
+    def test_get_private_topic(self, client, query_generator, topic_factory):
         topic = topic_factory(is_private=True)
 
-        query = {'query': f'{{ topic(id: {topic.id}) {{ title }} }}'}
-        response = client.post('/graphql', query)
+        query = query_generator.get_topic(topic.id)
+        response = client.post('/graphql', {'query': query})
 
         assert response.status_code == 200
         assert response.json()['data']['topic'] is None
 
     @pytest.mark.django_db
-    def test_get_topics(self, topic_factory, client):
+    def test_get_topics(self, client, query_generator, topic_factory):
         topic_factory(is_private=False)
         topic_factory(is_private=False)
 
-        query = {'query': '{ topics { title } }'}
-        response = client.post('/graphql', query)
+        query = query_generator.get_topics()
+        response = client.post('/graphql', {'query': query})
 
         assert response.status_code == 200
         assert len(response.json()['data']['topics']) == 2
         assert response.json()['data']['topics'][0]
 
     @pytest.mark.django_db
-    def test_get_private_topics(self, topic_factory, client):
+    def test_get_private_topics(self, client, query_generator, topic_factory):
         topic_factory(is_private=True)
         topic_factory(is_private=True)
 
-        query = {'query': '{ topics { title } }'}
-        response = client.post('/graphql', query)
+        query = query_generator.get_topics()
+        response = client.post('/graphql', {'query': query})
 
         assert response.status_code == 200
         assert len(response.json()['data']['topics']) == 2

--- a/tests/func/users/test_create_user.py
+++ b/tests/func/users/test_create_user.py
@@ -1,25 +1,27 @@
 import pytest
 
+from tests.resources.MutationGenerator import MutationGenerator
+
 
 class TestCreateUser:
 
     @pytest.mark.django_db
-    def test_unauthenticated(self, client, mutation_generator, user_factory):
+    def test_unauthenticated(self, client, user_factory):
         user = user_factory.build()
 
-        mutation = mutation_generator.create_user(email=user.email, username=user.username)
+        mutation = MutationGenerator.create_user(email=user.email, username=user.username)
         response = client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createUser'] is None
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_valid(self, auth_client, mutation_generator, user_factory):
+    def test_valid(self, auth_client, user_factory):
         user = user_factory.build()
 
-        mutation = mutation_generator.create_user(email=user.email, username=user.username)
+        mutation = MutationGenerator.create_user(email=user.email, username=user.username)
         response = auth_client.post('/graphql', {'query': mutation})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['createUser']['user']['alias']

--- a/tests/func/users/test_create_user.py
+++ b/tests/func/users/test_create_user.py
@@ -4,17 +4,10 @@ import pytest
 class TestCreateUser:
 
     @pytest.mark.django_db
-    def test_unauthenticated(self, client, user_factory):
+    def test_unauthenticated(self, client, mutation_generator, user_factory):
         user = user_factory.build()
-        mutation = f'''
-          mutation {{
-            createUser(input: {{email: "{user.email}", username: "{user.username}"}}) {{
-              user {{
-                alias
-              }}
-            }}
-          }}
-        '''
+
+        mutation = mutation_generator.create_user(email=user.email, username=user.username)
         response = client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200
@@ -22,18 +15,10 @@ class TestCreateUser:
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_valid(self, auth_client, user_factory):
+    def test_valid(self, auth_client, mutation_generator, user_factory):
         user = user_factory.build()
 
-        mutation = f'''
-          mutation {{
-            createUser(input: {{email: "{user.email}", username: "{user.username}"}}) {{
-              user {{
-                alias
-              }}
-            }}
-          }}
-        '''
+        mutation = mutation_generator.create_user(email=user.email, username=user.username)
         response = auth_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200

--- a/tests/func/users/test_query_users.py
+++ b/tests/func/users/test_query_users.py
@@ -1,36 +1,38 @@
 import pytest
 
+from tests.resources.QueryGenerator import QueryGenerator
+
 
 class TestQueryUsers:
 
     @pytest.mark.django_db
-    def test_get_user_unauthorized_fields(self, client, query_generator, user_factory):
+    def test_get_user_unauthorized_fields(self, client, user_factory):
         user = user_factory()
 
-        query = query_generator.get_user_authorized(user.id)
+        query = QueryGenerator.get_user_authorized(user.id)
         response = client.post('/graphql', {'query': query})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert not response.json()['data']['user']['slackUsers']
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_get_user_public_fields(self, client, query_generator, user_factory):
+    def test_get_user_public_fields(self, client, user_factory):
         user = user_factory()
 
-        query = query_generator.get_user(user.id)
+        query = QueryGenerator.get_user(user.id)
         response = client.post('/graphql', {'query': query})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert response.json()['data']['user']['alias'] == user.alias
 
     @pytest.mark.django_db
-    def test_get_users_authorized_fields(self, auth_client, query_generator, user_factory):
+    def test_get_users_authorized_fields(self, auth_client, user_factory):
         user_factory()
         user_factory()
 
-        query = query_generator.get_users_authorized()
+        query = QueryGenerator.get_users_authorized()
         response = auth_client.post('/graphql', {'query': query})
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
         assert len(response.json()['data']['users']) == 3

--- a/tests/func/users/test_query_users.py
+++ b/tests/func/users/test_query_users.py
@@ -4,33 +4,33 @@ import pytest
 class TestQueryUsers:
 
     @pytest.mark.django_db
-    def test_get_user_unauthorized_fields(self, user_factory, client):
+    def test_get_user_unauthorized_fields(self, client, query_generator, user_factory):
         user = user_factory()
 
-        query = {'query': f'{{ user(id: {user.id}) {{ slackUsers {{ id }} }} }}'}
-        response = client.post('/graphql', query)
+        query = query_generator.get_user_authorized(user.id)
+        response = client.post('/graphql', {'query': query})
 
         assert response.status_code == 200
         assert not response.json()['data']['user']['slackUsers']
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_get_user_public_fields(self, user_factory, client):
+    def test_get_user_public_fields(self, client, query_generator, user_factory):
         user = user_factory()
 
-        query = {'query': f'{{ user(id: {user.id}) {{ alias }} }}'}
-        response = client.post('/graphql', query)
+        query = query_generator.get_user(user.id)
+        response = client.post('/graphql', {'query': query})
 
         assert response.status_code == 200
         assert response.json()['data']['user']['alias'] == user.alias
 
     @pytest.mark.django_db
-    def test_get_users_authorized_fields(self, user_factory, auth_client):
+    def test_get_users_authorized_fields(self, auth_client, query_generator, user_factory):
         user_factory()
         user_factory()
 
-        query = {'query': '{ users { slackUsers { id } } }'}
-        response = auth_client.post('/graphql', query)
+        query = query_generator.get_users_authorized()
+        response = auth_client.post('/graphql', {'query': query})
 
         assert response.status_code == 200
         assert len(response.json()['data']['users']) == 3

--- a/tests/resources/MutationGenerator.py
+++ b/tests/resources/MutationGenerator.py
@@ -63,7 +63,7 @@ class SlackIntegrationMutationGenerator:
                 name
               }}
             }}
-          }}        
+          }}
         '''
         return mutation
 
@@ -186,8 +186,288 @@ class SlackIntegrationMutationGenerator:
         '''
         return mutation
 
+    @staticmethod
+    def create_topic_from_slack(title, description, is_private, original_poster_slack_user_id,
+                                tags):
+        tags = ','.join([f'{{name: "{tag.name}"}}' for tag in tags])
+        mutation = f'''
+          mutation {{
+            createTopicFromSlack(input: {{title: "{title}",
+                                          description: "{description}",
+                                          isPrivate: {is_private},
+                                          originalPosterSlackUserId: "{original_poster_slack_user_id}",
+                                          tags: [{tags}]}}) {{
+              topic {{
+                title
+                tags {{
+                  name
+                }}
+              }}
+            }}
+          }}
+        '''
+        return mutation
+
+    @staticmethod
+    def create_user_and_message_from_slack(id, name, first_name, last_name, real_name, display_name, email,
+                                           image_72, is_bot, is_admin, slack_team_id, origin_slack_event_ts,
+                                           slack_channel_id, text):
+        mutation = f'''
+          mutation {{
+            createUserAndMessageFromSlack(input: {{slackUser: {{id: "{id}",
+                                                                name: "{name}",
+                                                                firstName: "{first_name}",
+                                                                lastName: "{last_name}",
+                                                                realName: "{real_name}",
+                                                                displayName: "{display_name}",
+                                                                email: "{email}",
+                                                                image72: "{image_72}",
+                                                                isBot: {is_bot},
+                                                                isAdmin: {is_admin},
+                                                                slackTeamId: "{slack_team_id}"}},
+                                                    originSlackEventTs: "{origin_slack_event_ts}",
+                                                    slackChannelId: "{slack_channel_id}",
+                                                    text: "{text}"}}) {{
+              slackUser {{
+                user {{
+                  alias
+                }}
+              }}
+            }}
+          }}
+        '''
+        return mutation
+
+    @staticmethod
+    def create_user_and_reply_from_slack(id, name, first_name, last_name, real_name, display_name, email,
+                                         image_72, is_bot, is_admin, slack_team_id, message_origin_slack_event_ts,
+                                         origin_slack_event_ts, slack_channel_id, text):
+        mutation = f'''
+          mutation {{
+            createUserAndReplyFromSlack(input: {{slackUser: {{
+                                                   id: "{id}",
+                                                   name: "{name}",
+                                                   firstName: "{first_name}",
+                                                   lastName: "{last_name}",
+                                                   realName: "{real_name}",
+                                                   displayName: "{display_name}",
+                                                   email: "{email}",
+                                                   image72: "{image_72}",
+                                                   isBot: {is_bot},
+                                                   isAdmin: {is_admin},
+                                                   slackTeamId: "{slack_team_id}"
+                                                 }},
+                                                 messageOriginSlackEventTs: "{message_origin_slack_event_ts}",
+                                                 originSlackEventTs: "{origin_slack_event_ts}",
+                                                 slackChannelId: "{slack_channel_id}",
+                                                 text: "{text}"}}) {{
+              slackUser {{
+                id
+              }}
+              user {{
+                alias
+              }}
+              reply {{
+                message {{
+                  id
+                }}
+              }}
+            }}
+          }}
+        '''
+        return mutation
+
+    @staticmethod
+    def create_user_and_topic_from_slack(id, name, first_name, last_name, real_name, display_name, email,
+                                         image_72, is_bot, is_admin, slack_team_id, title, description,
+                                         is_private, tags):
+        tags = ','.join([f'{{name: "{tag.name}"}}' for tag in tags])
+        mutation = f'''
+          mutation {{
+            createUserAndTopicFromSlack(input: {{title: "{title}",
+                                                 description: "{description}",
+                                                 isPrivate: {is_private},
+                                                 originalPosterSlackUser: {{
+                                                   id: "{id}",
+                                                   name: "{name}",
+                                                   firstName: "{first_name}",
+                                                   lastName: "{last_name}",
+                                                   realName: "{real_name}",
+                                                   displayName: "{display_name}",
+                                                   email: "{email}",
+                                                   image72: "{image_72}",
+                                                   isBot: {is_bot},
+                                                   isAdmin: {is_admin},
+                                                   slackTeamId: "{slack_team_id}"
+                                                 }},
+                                                 tags: [{tags}]}}) {{
+              topic {{
+                title
+                tags {{
+                  name
+                }}
+              }}
+              slackUser {{
+                id
+              }}
+            }}
+          }}
+        '''
+        return mutation
+
+    @staticmethod
+    def create_user_from_slack(id, name, first_name, last_name, real_name, display_name, email,
+                               image_72, is_bot, is_admin, slack_team_id):
+        mutation = f'''
+          mutation {{
+            createUserFromSlack(input: {{id: "{id}",
+                                         name: "{name}",
+                                         firstName: "{first_name}",
+                                         lastName: "{last_name}",
+                                         realName: "{real_name}",
+                                         displayName: "{display_name}",
+                                         email: "{email}",
+                                         image72: "{image_72}",
+                                         isBot: {is_bot},
+                                         isAdmin: {is_admin},
+                                         slackTeamId: "{slack_team_id}"}}) {{
+              slackUser {{
+                user {{
+                  id
+                  alias
+                }}
+              }}
+            }}
+          }}
+        '''
+        return mutation
+
+    @staticmethod
+    def mark_discussion_as_pending_closed_from_slack(slack_channel_id):
+        mutation = f'''
+          mutation {{
+            markDiscussionAsPendingClosedFromSlack(input: {{slackChannelId: "{slack_channel_id}"}}) {{
+              discussion {{
+                status
+              }}
+            }}
+          }}
+        '''
+        return mutation
+
+    @staticmethod
+    def update_slack_agent_topic_channel_and_activate(slack_team_id, topic_channel_id):
+        mutation = f'''
+          mutation {{
+            updateSlackAgentTopicChannelAndActivate(input: {{slackTeamId: "{slack_team_id}",
+                                                            topicChannelId: "{topic_channel_id}"}}) {{
+              slackAgent {{
+                topicChannelId
+                status
+              }}
+            }}
+          }}
+        '''
+        return mutation
+
+
+class TopicsMutationGenerator:
+    @staticmethod
+    def close_discussion(discussion_id):
+        mutation = f'''
+          mutation {{
+            closeDiscussion(input: {{id: {discussion_id}}}) {{
+              discussion {{
+                id
+              }}
+            }}
+          }}
+        '''
+        return mutation
+
+    @staticmethod
+    def create_discussion(time_start, time_end, topic_id):
+        mutation = f'''
+          mutation {{
+            createDiscussion(input: {{timeStart: "{time_start}", timeEnd: "{time_end}",
+                                      topicId: {topic_id}}}) {{
+              discussion {{
+                topic {{
+                  id
+                }}
+              }}
+            }}
+          }}
+        '''
+        return mutation
+
+    @staticmethod
+    def create_tag(name):
+        mutation = f'''
+          mutation {{
+            createTag(input: {{name: "{name}"}}) {{
+              tag {{
+                name
+              }}
+            }}
+          }}
+        '''
+        return mutation
+
+    @staticmethod
+    def create_topic(title, description, is_private, original_poster_id, group_id, tags=''):
+        tags = ','.join([f'{{name: "{tag.name}"}}' for tag in tags]) if tags else tags
+        mutation = f'''
+          mutation {{
+            createTopic(input: {{title: "{title}",
+                                 description: "{description}",
+                                 isPrivate: {is_private},
+                                 originalPosterId: {original_poster_id},
+                                 groupId: {group_id},
+                                 tags: [{tags}]}}) {{
+              topic {{
+                title
+                tags {{
+                  name
+                }}
+              }}
+            }}
+          }}
+        '''
+        return mutation
+
+    @staticmethod
+    def mark_discussion_as_pending_closed(discussion_id):
+        mutation = f'''
+          mutation {{
+            markDiscussionAsPendingClosed(input: {{id: {discussion_id}}}) {{
+              discussion {{
+                status
+              }}
+            }}
+          }}
+        '''
+        return mutation
+
+
+class UsersMutationGenerator:
+    @staticmethod
+    def create_user(email, username):
+        mutation = f'''
+          mutation {{
+            createUser(input: {{email: "{email}", username: "{username}"}}) {{
+              user {{
+                alias
+              }}
+            }}
+          }}
+        '''
+        return mutation
+
 
 class MutationGenerator(DialoguesMutationGenerator,
                         GroupsMutationGenerator,
-                        SlackIntegrationMutationGenerator):
+                        SlackIntegrationMutationGenerator,
+                        TopicsMutationGenerator,
+                        UsersMutationGenerator):
     pass

--- a/tests/resources/MutationGenerator.py
+++ b/tests/resources/MutationGenerator.py
@@ -1,0 +1,193 @@
+class DialoguesMutationGenerator:
+    @staticmethod
+    def create_message(text, discussion_id, author_id, time):
+        mutation = f'''
+          mutation {{
+            createMessage(input: {{text: "{text}", discussionId: {discussion_id},
+                                   authorId: {author_id}, time: "{time}"}}) {{
+              message {{
+                text
+                discussion {{
+                  status
+                }}
+              }}
+            }}
+          }}
+        '''
+        return mutation
+
+    @staticmethod
+    def create_reply(text, message_id, author_id, time):
+        mutation = f'''
+          mutation {{
+            createReply(input: {{text: "{text}", messageId: {message_id},
+                                 authorId: {author_id}, time: "{time}"}}) {{
+              reply {{
+                text
+                message {{
+                  discussion {{
+                    status
+                  }}
+                }}
+              }}
+            }}
+          }}
+        '''
+        return mutation
+
+
+class GroupsMutationGenerator:
+    @staticmethod
+    def create_group(group_name):
+        mutation = f'''
+              mutation {{
+                createGroup(input: {{name: "{group_name}"}}) {{
+                  group {{
+                    name
+                  }}
+                }}
+              }}
+            '''
+        return mutation
+
+
+class SlackIntegrationMutationGenerator:
+    @staticmethod
+    def attempt_slack_installation(code, client_id, redirect_uri):
+        mutation = f'''
+          mutation {{
+            attemptSlackInstallation(input: {{code: "{code}",
+                                              clientId: "{client_id}",
+                                              redirectUri: "{redirect_uri}"}}) {{
+              slackTeam {{
+                name
+              }}
+            }}
+          }}        
+        '''
+        return mutation
+
+    @staticmethod
+    def close_discussion_from_slack(slack_channel_id, slack_user_id):
+        mutation = f'''
+          mutation {{
+            closeDiscussionFromSlack(input: {{slackChannelId: "{slack_channel_id}",
+                                              slackUserId: "{slack_user_id}"}}) {{
+              discussion {{
+                id
+                status
+              }}
+            }}
+          }}
+        '''
+        return mutation
+
+    @staticmethod
+    def create_discussion_from_slack(time_start, topic_id, id, name, slack_team_id):
+        mutation = f'''
+          mutation {{
+            createDiscussionFromSlack(input: {{discussion: {{timeStart: "{time_start}",
+                                                             topicId: {topic_id}}},
+                                               id: "{id}",
+                                               name: "{name}",
+                                               slackTeamId: "{slack_team_id}"}}) {{
+              discussion {{
+                id
+                topic {{
+                  id
+                }}
+              }}
+              slackChannel {{
+                name
+              }}
+            }}
+          }}
+        '''
+        return mutation
+
+    @staticmethod
+    def create_message_from_slack(text, slack_channel_id, slack_user_id, origin_slack_event_ts):
+        mutation = f'''
+          mutation {{
+            createMessageFromSlack(input: {{text: "{text}", slackChannelId: "{slack_channel_id}",
+                                            slackUserId: "{slack_user_id}",
+                                            originSlackEventTs: "{origin_slack_event_ts}"}}) {{
+              message {{
+                author {{
+                  id
+                }}
+                discussion {{
+                  id
+                  participants {{
+                    id
+                  }}
+                }}
+              }}
+            }}
+          }}
+        '''
+        return mutation
+
+    @staticmethod
+    def create_reply_from_slack(text, message_origin_slack_event_ts, slack_channel_id, slack_user_id,
+                                origin_slack_event_ts):
+        mutation = f'''
+          mutation {{
+            createReplyFromSlack(input: {{text: "{text}",
+                                          messageOriginSlackEventTs: "{message_origin_slack_event_ts}",
+                                          slackChannelId: "{slack_channel_id}",
+                                          slackUserId: "{slack_user_id}",
+                                          originSlackEventTs: "{origin_slack_event_ts}"}}) {{
+              reply {{
+                time
+                message {{
+                  author {{
+                    id
+                  }}
+                  discussion {{
+                    participants {{
+                      id
+                    }}
+                  }}
+                }}
+              }}
+            }}
+          }}
+        '''
+        return mutation
+
+    @staticmethod
+    def create_slack_channel(id, name, slack_team_id, discussion_id):
+        mutation = f'''
+          mutation {{
+            createSlackChannel(input: {{id: "{id}", name: "{name}", slackTeamId: "{slack_team_id}",
+                                        discussionId: {discussion_id}}}) {{
+              slackChannel {{
+                name
+              }}
+            }}
+          }}
+        '''
+        return mutation
+
+    @staticmethod
+    def create_slack_user(id, name, real_name, display_name, image_72, is_bot, is_admin,
+                          slack_team_id, user_id):
+        mutation = f'''
+          mutation {{
+            createSlackUser(input: {{id: "{id}", name: "{name}", realName: "{real_name}", displayName: "{display_name}",
+                                     image72: "{image_72}", isBot: {is_bot}, isAdmin: {is_admin},
+                                     slackTeamId: "{slack_team_id}", userId: {user_id}}}) {{
+              slackUser {{
+                id
+              }}
+            }}
+          }}
+        '''
+        return mutation
+
+
+class MutationGenerator(DialoguesMutationGenerator,
+                        GroupsMutationGenerator,
+                        SlackIntegrationMutationGenerator):
+    pass

--- a/tests/resources/QueryGenerator.py
+++ b/tests/resources/QueryGenerator.py
@@ -46,5 +46,226 @@ class DialoguesQueryGenerator:
         return query
 
 
-class QueryGenerator(DialoguesQueryGenerator):
+class SlackIntegrationQueryGenerator:
+    @staticmethod
+    def get_slack_application_installation(slack_application_installation_id):
+        query = f'''
+          query {{
+            slackApplicationInstallation(id: {slack_application_installation_id}) {{
+              botAccessToken
+            }}
+          }}
+        '''
+        return query
+
+    @staticmethod
+    def get_slack_application_installations():
+        query = '''
+          query {
+            slackApplicationInstallations {
+              botAccessToken
+            }
+          }
+        '''
+        return query
+
+    @staticmethod
+    def get_active_slack_application_installations():
+        query = '''
+          query {
+            slackApplicationInstallations (agentStatus: "ACTIVE") {
+              botAccessToken
+            }
+          }
+        '''
+        return query
+
+    @staticmethod
+    def get_slack_channel(slack_channel_id):
+        query = f'''
+          query {{
+            slackChannel(id: "{slack_channel_id}") {{
+              name
+            }}
+          }}
+        '''
+        return query
+
+    @staticmethod
+    def get_slack_channels():
+        query = '''
+          query {
+            slackChannels {
+              name
+            }
+          }
+        '''
+        return query
+
+    @staticmethod
+    def get_slack_team(slack_team_id):
+        query = f'''
+          query {{
+            slackTeam(id: "{slack_team_id}") {{
+              name
+            }}
+          }}
+        '''
+        return query
+
+    @staticmethod
+    def get_slack_teams():
+        query = '''
+          query {
+            slackTeams {
+              slackAgent {
+                group {
+                  name
+                }
+              }
+            }
+          }
+        '''
+        return query
+
+    @staticmethod
+    def get_slack_user(slack_user_id):
+        query = f'''
+          query {{
+            slackUser(id: "{slack_user_id}") {{
+              displayName
+              id
+            }}
+          }}
+        '''
+        return query
+
+    @staticmethod
+    def get_slack_users():
+        query = '''
+          query {
+            slackUsers {
+              user {
+                id
+              }
+            }
+          }
+        '''
+        return query
+
+
+class TopicsQueryGenerator:
+    @staticmethod
+    def get_discussion(discussion_id):
+        query = f'''
+          query {{
+            discussion(id: {discussion_id}) {{
+              status
+              topic {{
+                title
+              }}
+            }}
+          }}
+        '''
+        return query
+
+    @staticmethod
+    def get_discussions():
+        query = '''
+          query {
+            discussions {
+              id
+            }
+          }
+        '''
+        return query
+
+    @staticmethod
+    def get_tag(tag_name):
+        query = f'''
+          query {{
+            tag(name: "{tag_name}") {{
+              id
+            }}
+          }}
+        '''
+        return query
+
+    @staticmethod
+    def get_tags():
+        query = '''
+          query {
+            tags {
+              name
+            }
+          }
+        '''
+        return query
+
+    @staticmethod
+    def get_topic(topic_id):
+        query = f'''
+          query {{
+            topic(id: {topic_id}) {{
+              title
+            }}
+          }}
+        '''
+        return query
+
+    @staticmethod
+    def get_topics():
+        query = '''
+          query {
+            topics {
+              title
+            }
+          }
+        '''
+        return query
+
+
+class UsersQueryGenerator:
+    @staticmethod
+    def get_user(user_id):
+        query = f'''
+          query {{
+            user(id: {user_id}) {{
+              alias
+            }}
+          }}
+        '''
+        return query
+
+    @staticmethod
+    def get_user_authorized(user_id):
+        query = f'''
+          query {{
+            user(id: {user_id}) {{
+              slackUsers {{
+                id
+              }}
+            }}
+          }}
+        '''
+        return query
+
+    @staticmethod
+    def get_users_authorized():
+        query = '''
+          query {
+            users {
+              slackUsers {
+                id
+              }
+            }
+          }
+        '''
+        return query
+
+
+class QueryGenerator(DialoguesQueryGenerator,
+                     SlackIntegrationQueryGenerator,
+                     TopicsQueryGenerator,
+                     UsersQueryGenerator):
     pass

--- a/tests/resources/QueryGenerator.py
+++ b/tests/resources/QueryGenerator.py
@@ -46,6 +46,30 @@ class DialoguesQueryGenerator:
         return query
 
 
+class GroupsQueryGenerator:
+    @staticmethod
+    def get_group(group_name):
+        query = f'''
+          query {{
+            group(name: "{group_name}") {{
+              id
+            }}
+          }}
+        '''
+        return query
+
+    @staticmethod
+    def get_groups():
+        query = '''
+          query {
+            groups {
+              name
+            }
+          }
+        '''
+        return query
+
+
 class SlackIntegrationQueryGenerator:
     @staticmethod
     def get_slack_application_installation(slack_application_installation_id):
@@ -265,6 +289,7 @@ class UsersQueryGenerator:
 
 
 class QueryGenerator(DialoguesQueryGenerator,
+                     GroupsQueryGenerator,
                      SlackIntegrationQueryGenerator,
                      TopicsQueryGenerator,
                      UsersQueryGenerator):

--- a/tests/resources/QueryGenerator.py
+++ b/tests/resources/QueryGenerator.py
@@ -1,0 +1,50 @@
+class DialoguesQueryGenerator:
+    @staticmethod
+    def get_message(message_id):
+        query = f'''
+          query {{
+            message(id: {message_id}) {{
+              text
+            }}
+          }}
+        '''
+        return query
+
+    @staticmethod
+    def get_messages():
+        query = '''
+          query {
+            messages {
+              text
+            }
+          }
+        '''
+        return query
+
+    @staticmethod
+    def get_reply(reply_id):
+        query = f'''
+          query {{
+            reply(id: {reply_id}) {{
+              message {{
+                text
+              }}
+            }}
+          }}
+        '''
+        return query
+
+    @staticmethod
+    def get_replies():
+        query = '''
+          query {
+            replies {
+              text
+            }
+          }
+        '''
+        return query
+
+
+class QueryGenerator(DialoguesQueryGenerator):
+    pass

--- a/tests/resources/test_celery_tasks.py
+++ b/tests/resources/test_celery_tasks.py
@@ -22,13 +22,13 @@ def execute_task_periodically(task, num_periods, period_length, args=None):
         time.sleep(period_length)
 
 
-def auto_close_pending_closed_discussion_task(args, countdown):
+def run_auto_close_pending_closed_discussion_task(args, countdown):
     thread = threading.Thread(target=execute_task_with_countdown, args=(auto_close_pending_closed_discussion,),
                               kwargs={'args': args, 'countdown': countdown}, daemon=True)
     thread.start()
 
 
-def mark_stale_discussions_task(num_periods=3, period_length=2.5):
+def run_mark_stale_discussions_task(num_periods=3, period_length=2.5):
     thread = threading.Thread(target=execute_task_periodically,
                               args=(mark_stale_discussions, num_periods, period_length),
                               daemon=True)


### PR DESCRIPTION
- Use waffle to check a switch called `use_slack_domain`. If this is `True`, we'll send the typical slack domain data. If this is `False`, we'll send the discussion id. This is manageable from Django Admin.
- Did some minor renaming and added in a fixture for creating this switch and setting to active.