### PR TITLE
API-151: Check object-level permissions on resolvers

### DIFF
--- a/app/api/authorization.py
+++ b/app/api/authorization.py
@@ -1,4 +1,6 @@
 from rest_framework.authentication import TokenAuthentication
+from django.db import models
+from guardian.shortcuts import get_perms
 
 
 def get_user(context):
@@ -12,18 +14,27 @@ def get_user(context):
     return user
 
 
-def check_authorization(resolve_function):
-    """
-    Performs authorization checks for type fields.
+def authorize(object_level=False, raise_exception=False):
+    def check_authorization(resolve_function):
+        """
+        Performs authorization checks with django-guardian.
 
-    Checks to see if info.context.user.is_authenticated
-    is true. If so, the resolve function is called. If
-    false, an exception is raised.
-    """
-    def wrapper(self, info, **kwargs):
-        user = get_user(info.context)
-        if user and user.is_authenticated:
-            return resolve_function(self, info, **kwargs)
-        else:
-            raise Exception('Unauthorized')
-    return wrapper
+        Checks to see if the user is authenticated and has
+        view permissions for the object requested.
+        """
+        def wrapper(self, info, **kwargs):
+            user = get_user(info.context)
+
+            if user and user.is_authenticated:
+                if object_level and issubclass(self.__class__, models.Model):
+                    if any('view_' in perm for perm in get_perms(user, self)):
+                        return resolve_function(self, info, **kwargs)
+                else:
+                    return resolve_function(self, info, **kwargs)
+
+            if raise_exception:
+                raise Exception('Unauthorized')
+
+            return None
+        return wrapper
+    return check_authorization

--- a/app/strands/models.py
+++ b/app/strands/models.py
@@ -64,8 +64,8 @@ def assign_permissions(sender, instance, created, **kwargs):
         assign_perm('delete_strand', instance.original_poster, instance)
         assign_perm('view_strand', instance.original_poster, instance)
 
-# TODO: Receiver to delete orphans
+# TODO: [API-150] Receiver to delete orphans
 # http://django-guardian.readthedocs.io/en/stable/userguide/caveats.html
 
-# TODO: Migration to add "add_strand" and "add_tag" permissions to users
+# TODO: [API-160] Migration to add "add_strand" and "add_tag" permissions to users
 # https://docs.djangoproject.com/en/2.0/topics/auth/default/#permissions-and-authorization

--- a/app/strands/mutations.py
+++ b/app/strands/mutations.py
@@ -16,6 +16,7 @@ class CreateStrandMutation(graphene.Mutation):
 
     strand = graphene.Field(StrandType)
 
+    # TODO: [API-153] Move to authorization to model
     @authorize(raise_exception=True)
     def mutate(self, info, input):
         strand_validator = StrandValidator(data=input)
@@ -30,6 +31,7 @@ class CreateTagMutation(graphene.Mutation):
 
     tag = graphene.Field(TagType)
 
+    # TODO: [API-153] Move to authorization to model
     @authorize(raise_exception=True)
     def mutate(self, info, input):
         tag_validator = TagValidator(data=input)

--- a/app/strands/mutations.py
+++ b/app/strands/mutations.py
@@ -1,6 +1,6 @@
 import graphene
 
-from app.api.authorization import check_authorization
+from app.api.authorization import authorize
 from app.strands.types import (
     StrandType,
     StrandInputType,
@@ -16,7 +16,7 @@ class CreateStrandMutation(graphene.Mutation):
 
     strand = graphene.Field(StrandType)
 
-    @check_authorization
+    @authorize(raise_exception=True)
     def mutate(self, info, input):
         strand_validator = StrandValidator(data=input)
         strand_validator.is_valid(raise_exception=True)
@@ -30,7 +30,7 @@ class CreateTagMutation(graphene.Mutation):
 
     tag = graphene.Field(TagType)
 
-    @check_authorization
+    @authorize(raise_exception=True)
     def mutate(self, info, input):
         tag_validator = TagValidator(data=input)
         tag_validator.is_valid(raise_exception=True)

--- a/app/strands/types.py
+++ b/app/strands/types.py
@@ -1,6 +1,7 @@
 import graphene
 from graphene_django.types import DjangoObjectType
 
+from app.api.authorization import authorize
 from app.strands.models import Strand, Tag
 
 
@@ -9,11 +10,51 @@ class TagType(DjangoObjectType):
         model = Tag
         only_fields = ('id', 'name', 'strands',)
 
+    @authorize(object_level=True)
+    def resolve_id(self, info):
+        return self.id
+
+    @authorize(object_level=True)
+    def resolve_name(self, info):
+        return self.name
+
+    @authorize(object_level=True)
+    def resolve_strands(self, info):
+        return self.strands
+
 
 class StrandType(DjangoObjectType):
     class Meta:
         model = Strand
         only_fields = ('id', 'title', 'body', 'timestamp', 'original_poster', 'owner', 'tags', )
+
+    @authorize(object_level=True)
+    def resolve_id(self, info):
+        return self.id
+
+    @authorize(object_level=True)
+    def resolve_title(self, info):
+        return self.title
+
+    @authorize(object_level=True)
+    def resolve_body(self, info):
+        return self.body
+
+    @authorize(object_level=True)
+    def resolve_timestamp(self, info):
+        return self.timestamp
+
+    @authorize(object_level=True)
+    def resolve_original_poster(self, info):
+        return self.original_poster
+
+    @authorize(object_level=True)
+    def resolve_owner(self, info):
+        return self.owner
+
+    @authorize(object_level=True)
+    def resolve_tags(self, info):
+        return self.tags
 
 
 class TagInputType(graphene.InputObjectType):

--- a/app/teams/models.py
+++ b/app/teams/models.py
@@ -28,7 +28,7 @@ class Team(TimeStampedModel):
     members = models.ManyToManyField(to=User, related_name='teams')
     group = models.OneToOneField(to=Group, related_name='team', on_delete=models.CASCADE)
 
-    # TODO: Should we have a role associated with team (e.g. creator)
+    # TODO: [API-159] Should we have a role associated with team (e.g. creator)
 
     class Meta:
         permissions = (
@@ -67,8 +67,8 @@ def update_group(sender, instance, action, pk_set, **kwargs):
         instance.group.user_set.remove(*pk_set)
         remove_perm('view_user', instance.group, members)
 
-# TODO: Receiver to delete orphans
+# TODO: [API-150] Receiver to delete orphans
 # http://django-guardian.readthedocs.io/en/stable/userguide/caveats.html
 
-# TODO: Migration to add "add_team" permission to users
+# TODO: [API-160] Migration to add "add_team" permission to users
 # https://docs.djangoproject.com/en/2.0/topics/auth/default/#permissions-and-authorization

--- a/app/teams/models.py
+++ b/app/teams/models.py
@@ -28,6 +28,8 @@ class Team(TimeStampedModel):
     members = models.ManyToManyField(to=User, related_name='teams')
     group = models.OneToOneField(to=Group, related_name='team', on_delete=models.CASCADE)
 
+    # TODO: Should we have a role associated with team (e.g. creator)
+
     class Meta:
         permissions = (
             ('view_team', 'View team'),  # add_team, change_team and delete_team are added by default

--- a/app/teams/mutations.py
+++ b/app/teams/mutations.py
@@ -11,7 +11,7 @@ class CreateTeamMutation(graphene.Mutation):
 
     team = graphene.Field(TeamType)
 
-    # TODO: Move to authorization to model
+    # TODO: [API-153] Move to authorization to model
     @authorize(raise_exception=True)
     def mutate(self, info, input):
         team_validator = TeamValidator(data=input)

--- a/app/teams/mutations.py
+++ b/app/teams/mutations.py
@@ -1,6 +1,6 @@
 import graphene
 
-from app.api.authorization import check_authorization
+from app.api.authorization import authorize
 from app.teams.validators import TeamValidator
 from app.teams.types import TeamType, TeamInputType
 
@@ -11,7 +11,8 @@ class CreateTeamMutation(graphene.Mutation):
 
     team = graphene.Field(TeamType)
 
-    @check_authorization
+    # TODO: Move to authorization to model
+    @authorize(raise_exception=True)
     def mutate(self, info, input):
         team_validator = TeamValidator(data=input)
         team_validator.is_valid(raise_exception=True)

--- a/app/teams/types.py
+++ b/app/teams/types.py
@@ -28,4 +28,5 @@ class TeamType(DjangoObjectType):
 
 
 class TeamInputType(graphene.InputObjectType):
+    # TODO: FKs of users to include on creation
     name = graphene.String(required=True)

--- a/app/teams/types.py
+++ b/app/teams/types.py
@@ -28,5 +28,5 @@ class TeamType(DjangoObjectType):
 
 
 class TeamInputType(graphene.InputObjectType):
-    # TODO: FKs of users to include on creation
+    # TODO: [API-157] FKs of users to include on creation
     name = graphene.String(required=True)

--- a/app/teams/types.py
+++ b/app/teams/types.py
@@ -1,12 +1,30 @@
 import graphene
 from graphene_django.types import DjangoObjectType
 
+from app.api.authorization import authorize
 from app.teams.models import Team
 
 
 class TeamType(DjangoObjectType):
     class Meta:
         model = Team
+        only_fields = ('id', 'name', 'members', 'strands',)
+
+    @authorize(object_level=True)
+    def resolve_id(self, info):
+        return self.id
+
+    @authorize(object_level=True)
+    def resolve_name(self, info):
+        return self.name
+
+    @authorize(object_level=True)
+    def resolve_members(self, info):
+        return self.members
+
+    @authorize(object_level=True)
+    def resolve_strands(self, info):
+        return self.strands
 
 
 class TeamInputType(graphene.InputObjectType):

--- a/app/teams/validators.py
+++ b/app/teams/validators.py
@@ -6,6 +6,8 @@ from app.teams.models import Team
 
 
 class TeamValidator(serializers.ModelSerializer):
+    # TODO: FKs of users to include on creation
+
     class Meta:
         model = Team
         fields = ('id', 'name')

--- a/app/teams/validators.py
+++ b/app/teams/validators.py
@@ -6,7 +6,7 @@ from app.teams.models import Team
 
 
 class TeamValidator(serializers.ModelSerializer):
-    # TODO: FKs of users to include on creation
+    # TODO: [API-157] FKs of users to include on creation
 
     class Meta:
         model = Team

--- a/app/users/models.py
+++ b/app/users/models.py
@@ -46,5 +46,5 @@ def create_token_and_add_permissions(sender, instance=None, created=False, **kwa
         assign_perm('change_user', instance, instance)
         assign_perm('delete_user', instance, instance)
 
-# TODO: Receiver to delete orphans
+# TODO: [API-150] Receiver to delete orphans
 # http://django-guardian.readthedocs.io/en/stable/userguide/caveats.html

--- a/app/users/mutations.py
+++ b/app/users/mutations.py
@@ -11,7 +11,7 @@ class CreateUserMutation(graphene.Mutation):
 
     user = graphene.Field(UserType)
 
-    # TODO: Move to authorization to model
+    # TODO: [API-153] Move to authorization to model
     @authorize(raise_exception=True)
     def mutate(self, info, input):
         user_validator = UserValidator(data=input)

--- a/app/users/mutations.py
+++ b/app/users/mutations.py
@@ -1,6 +1,6 @@
 import graphene
 
-from app.api.authorization import check_authorization
+from app.api.authorization import authorize
 from app.users.types import UserInputType, UserType
 from app.users.validators import UserValidator
 
@@ -11,7 +11,8 @@ class CreateUserMutation(graphene.Mutation):
 
     user = graphene.Field(UserType)
 
-    @check_authorization
+    # TODO: Move to authorization to model
+    @authorize(raise_exception=True)
     def mutate(self, info, input):
         user_validator = UserValidator(data=input)
         user_validator.is_valid(raise_exception=True)

--- a/app/users/types.py
+++ b/app/users/types.py
@@ -1,7 +1,7 @@
 import graphene
 from graphene_django.types import DjangoObjectType
 
-from app.api.authorization import check_authorization
+from app.api.authorization import authorize
 from app.teams.types import TeamType
 from app.users.models import User
 
@@ -11,14 +11,27 @@ class UserType(DjangoObjectType):
 
     class Meta:
         model = User
-        only_fields = ('id', 'email', 'teams')
+        only_fields = ('id', 'email', 'first_name', 'last_name', 'teams', 'strands',)
 
-    @check_authorization
+    @authorize(object_level=True)
     def resolve_email(self, info):
         return self.email
 
+    @authorize(object_level=True)
+    def resolve_first_name(self, info):
+        return self.first_name
+
+    @authorize(object_level=True)
+    def resolve_last_name(self, info):
+        return self.last_name
+
+    @authorize(object_level=True)
     def resolve_teams(self, info):
         return self.teams.all()
+
+    @authorize(object_level=True)
+    def resolve_strands(self, info):
+        return self.strands.all()
 
 
 class UserInputType(graphene.InputObjectType):

--- a/app/users/types.py
+++ b/app/users/types.py
@@ -2,13 +2,10 @@ import graphene
 from graphene_django.types import DjangoObjectType
 
 from app.api.authorization import authorize
-from app.teams.types import TeamType
 from app.users.models import User
 
 
 class UserType(DjangoObjectType):
-    teams = graphene.List(TeamType)
-
     class Meta:
         model = User
         only_fields = ('id', 'email', 'first_name', 'last_name', 'teams', 'strands',)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ register(UserFactory)
 
 
 @pytest.fixture()
-def auth_client(user_factory):
+def user_client(user_factory):
     """Pytest fixture for authenticated API client
 
     Most of our mutations require authentication. Rather than authenticate
@@ -28,4 +28,22 @@ def auth_client(user_factory):
     client = APIClient()
     token = Token.objects.get(user=user)
     client.credentials(HTTP_AUTHORIZATION=f'Token {token}')
+    setattr(client, 'user', user)
+    return client
+
+
+@pytest.fixture()
+def superuser_client(user_factory):
+    """Pytest fixture for authenticated API client
+
+    Most of our mutations require authentication. Rather than authenticate
+    with a mock user each time, this fixture allows us to use an already
+    authenticated api client. We use a superuser that represents the
+    permissions we would have when interacting with API from SLA.
+    """
+    user = user_factory(is_superuser=True)
+    client = APIClient()
+    token = Token.objects.get(user=user)
+    client.credentials(HTTP_AUTHORIZATION=f'Token {token}')
+    setattr(client, 'user', user)
     return client

--- a/tests/func/strands/test_create_strand.py
+++ b/tests/func/strands/test_create_strand.py
@@ -4,6 +4,7 @@ from tests.resources.MutationGenerator import MutationGenerator
 
 
 class TestCreateStrand:
+    # TODO: Break out creating strands as superuser vs regular user after v0.3
 
     @pytest.mark.django_db
     def test_unauthenticated(self, client, strand_factory, user_factory, team_factory):
@@ -23,37 +24,37 @@ class TestCreateStrand:
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_invalid_original_poster(self, auth_client, strand_factory, user_factory, team_factory):
-        original_poster = user_factory()
-        owner = team_factory()
+    def test_invalid_original_poster(self, superuser_client, user_factory, team_factory, strand_factory):
+        jimmy = user_factory()
+        owner = team_factory(members=[jimmy])
         strand = strand_factory.build()
 
         mutation = MutationGenerator.create_strand(title=strand.title,
                                                    body=strand.body,
                                                    timestamp=strand.timestamp,
-                                                   original_poster_id=original_poster.id + 1,
+                                                   original_poster_id=jimmy.id + 1,
                                                    owner_id=owner.id)
-        response = auth_client.post('/graphql', {'query': mutation})
+        response = superuser_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200, response.content
         assert not response.json()['data']['createStrand']
         assert response.json()['errors'][0]['message'] == str({'original_poster_id':
-                                                               [f'Invalid pk "{original_poster.id + 1}" '
+                                                               [f'Invalid pk "{jimmy.id + 1}" '
                                                                 f'- object does not exist.']
                                                                })
 
     @pytest.mark.django_db
-    def test_invalid_owner(self, auth_client, strand_factory, user_factory, team_factory):
-        original_poster = user_factory()
-        owner = team_factory()
+    def test_invalid_owner(self, superuser_client, user_factory, team_factory, strand_factory):
+        jimmy = user_factory()
+        owner = team_factory(members=[jimmy])
         strand = strand_factory.build()
 
         mutation = MutationGenerator.create_strand(title=strand.title,
                                                    body=strand.body,
                                                    timestamp=strand.timestamp,
-                                                   original_poster_id=original_poster.id,
+                                                   original_poster_id=jimmy.id,
                                                    owner_id=owner.id + 1)
-        response = auth_client.post('/graphql', {'query': mutation})
+        response = superuser_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200, response.content
         assert not response.json()['data']['createStrand']
@@ -63,53 +64,53 @@ class TestCreateStrand:
                                                                })
 
     @pytest.mark.django_db
-    def test_valid_add_existing_tags(self, auth_client, strand_factory, user_factory, team_factory, tag_factory):
-        original_poster = user_factory()
-        owner = team_factory(members=[original_poster])
+    def test_valid_add_existing_tags(self, superuser_client, user_factory, team_factory, strand_factory, tag_factory):
+        jimmy = user_factory()
+        owner = team_factory(members=[jimmy])
         strand = strand_factory.build()
 
         mutation = MutationGenerator.create_strand(title=strand.title,
                                                    body=strand.body,
                                                    timestamp=strand.timestamp,
-                                                   original_poster_id=original_poster.id,
+                                                   original_poster_id=jimmy.id,
                                                    owner_id=owner.id,
                                                    tags=[tag_factory().name, tag_factory().name])
-        response = auth_client.post('/graphql', {'query': mutation})
+        response = superuser_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200, response.content
         assert response.json()['data']['createStrand']['strand']['title']
         assert len(response.json()['data']['createStrand']['strand']['tags']) == 2
 
     @pytest.mark.django_db
-    def test_valid_create_new_tags(self, auth_client, strand_factory, user_factory, team_factory, tag_factory):
-        original_poster = user_factory()
-        owner = team_factory(members=[original_poster])
+    def test_valid_create_new_tags(self, superuser_client, user_factory, team_factory, strand_factory, tag_factory):
+        jimmy = user_factory()
+        owner = team_factory(members=[jimmy])
         strand = strand_factory.build()
 
         mutation = MutationGenerator.create_strand(title=strand.title,
                                                    body=strand.body,
                                                    timestamp=strand.timestamp,
-                                                   original_poster_id=original_poster.id,
+                                                   original_poster_id=jimmy.id,
                                                    owner_id=owner.id,
                                                    tags=[tag_factory.build().name, tag_factory.build().name])
-        response = auth_client.post('/graphql', {'query': mutation})
+        response = superuser_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200, response.content
         assert response.json()['data']['createStrand']['strand']['title']
         assert len(response.json()['data']['createStrand']['strand']['tags']) == 2
 
     @pytest.mark.django_db
-    def test_valid(self, auth_client, strand_factory, user_factory, team_factory):
-        original_poster = user_factory()
-        owner = team_factory(members=[original_poster])
+    def test_valid(self, superuser_client, user_factory, team_factory, strand_factory):
+        jimmy = user_factory()
+        owner = team_factory(members=[jimmy])
         strand = strand_factory.build()
 
         mutation = MutationGenerator.create_strand(title=strand.title,
                                                    body=strand.body,
                                                    timestamp=strand.timestamp,
-                                                   original_poster_id=original_poster.id,
+                                                   original_poster_id=jimmy.id,
                                                    owner_id=owner.id)
-        response = auth_client.post('/graphql', {'query': mutation})
+        response = superuser_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200, response.content
         assert response.json()['data']['createStrand']['strand']['title']

--- a/tests/func/strands/test_create_tag.py
+++ b/tests/func/strands/test_create_tag.py
@@ -4,6 +4,8 @@ from tests.resources.MutationGenerator import MutationGenerator
 
 
 class TestCreateTag:
+    # TODO: Break out creating tags as superuser vs regular user after v0.3
+
     @pytest.mark.django_db
     def test_unauthenticated(self, client, tag_factory):
         mutation = MutationGenerator.create_tag(name=tag_factory.build().name)
@@ -14,10 +16,19 @@ class TestCreateTag:
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_invalid_name(self, auth_client, tag_factory):
+    def test_invalid_name(self, superuser_client, tag_factory):
         mutation = MutationGenerator.create_tag(name=tag_factory().name)
-        response = auth_client.post('/graphql', {'query': mutation})
+        response = superuser_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200, response.content
         assert not response.json()['data']['createTag']
         assert response.json()['errors'][0]['message'] == str({'name': ['tag with this name already exists.']})
+
+    @pytest.mark.django_db
+    def test_valid(self, superuser_client, tag_factory):
+        tag = tag_factory.build()
+        mutation = MutationGenerator.create_tag(name=tag.name)
+        response = superuser_client.post('/graphql', {'query': mutation})
+
+        assert response.status_code == 200, response.content
+        assert response.json()['data']['createTag']['tag']['name'] == tag.name

--- a/tests/func/strands/test_query_strands.py
+++ b/tests/func/strands/test_query_strands.py
@@ -4,24 +4,63 @@ from tests.resources.QueryGenerator import QueryGenerator
 
 
 class TestQueryStrands:
-
     @pytest.mark.django_db
-    def test_get_strand(self, client, strand_factory):
-        strand = strand_factory()
+    def test_unauthenticated(self, client, user_factory, strand_factory):
+        jimmy = user_factory()
+        strand = strand_factory(original_poster=jimmy)
 
         query = QueryGenerator.get_strand(strand_id=strand.id)
         response = client.post('/graphql', {'query': query})
 
         assert response.status_code == 200, response.content
+        assert not response.json()['data']['strand']
+
+    @pytest.mark.django_db
+    def test_get_user_strand(self, user_client, strand_factory):
+        jimmy = user_client.user
+        strand = strand_factory(original_poster=jimmy)
+
+        query = QueryGenerator.get_strand(strand_id=strand.id)
+        response = user_client.post('/graphql', {'query': query})
+
+        assert response.status_code == 200, response.content
         assert response.json()['data']['strand']['title']
 
     @pytest.mark.django_db
-    def test_get_strands(self, client, strand_factory):
-        strand_factory()
-        strand_factory()
+    def test_get_team_strand(self, user_client, user_factory, team_factory, strand_factory):
+        jimmy = user_client.user
+        bobby = user_factory()
+        team = team_factory(members=[jimmy, bobby])
+        strand = strand_factory(original_poster=bobby, owner=team)
 
-        query = QueryGenerator.get_strands()
-        response = client.post('/graphql', {'query': query})
+        query = QueryGenerator.get_strand(strand_id=strand.id)
+        response = user_client.post('/graphql', {'query': query})
 
         assert response.status_code == 200, response.content
-        assert len(response.json()['data']['strands']) == 2
+        assert response.json()['data']['strand']['title']
+
+    @pytest.mark.django_db
+    def test_get_other_strand(self, user_client, user_factory, strand_factory):
+        bobby = user_factory()
+        strand = strand_factory(original_poster=bobby)
+
+        query = QueryGenerator.get_strand(strand_id=strand.id)
+        response = user_client.post('/graphql', {'query': query})
+
+        assert response.status_code == 200, response.content
+        assert not response.json()['data']['strand']
+
+    @pytest.mark.django_db
+    def test_get_strands(self, user_client, strand_factory, user_factory, team_factory):
+        jimmy = user_client.user
+        bobby = user_factory()
+        team = team_factory(members=[jimmy, bobby])
+        strand_factory(original_poster=bobby, owner=team)  # Same team
+        strand_factory(original_poster=bobby)  # Different user, different team
+        strand_factory(original_poster=jimmy)  # Same user
+
+        query = QueryGenerator.get_strands()
+        response = user_client.post('/graphql', {'query': query})
+
+        assert response.status_code == 200, response.content
+        assert len([strand for strand in response.json()['data']['strands'] if strand]) == 2

--- a/tests/func/strands/test_query_tags.py
+++ b/tests/func/strands/test_query_tags.py
@@ -6,22 +6,32 @@ from tests.resources.QueryGenerator import QueryGenerator
 class TestQueryTags:
 
     @pytest.mark.django_db
-    def test_get_tag(self, client, tag_factory):
+    def test_unauthenticated(self, client, tag_factory):
         tag = tag_factory()
 
         query = QueryGenerator.get_tag(tag_name=tag.name)
         response = client.post('/graphql', {'query': query})
 
         assert response.status_code == 200, response.content
-        assert response.json()['data']['tag']['name']
+        assert not response.json()['data']['tag']
 
     @pytest.mark.django_db
-    def test_get_tags(self, client, tag_factory):
+    def test_get_tag(self, user_client, tag_factory):
+        tag = tag_factory()
+
+        query = QueryGenerator.get_tag(tag_name=tag.name)
+        response = user_client.post('/graphql', {'query': query})
+
+        assert response.status_code == 200, response.content
+        assert response.json()['data']['tag']['name'] == tag.name
+
+    @pytest.mark.django_db
+    def test_get_tags(self, user_client, tag_factory):
         tag_factory()
         tag_factory()
 
         query = QueryGenerator.get_tags()
-        response = client.post('/graphql', {'query': query})
+        response = user_client.post('/graphql', {'query': query})
 
         assert response.status_code == 200, response.content
-        assert len(response.json()['data']['tags']) == 2
+        assert len([tag for tag in response.json()['data']['tags'] if tag]) == 2

--- a/tests/func/teams/test_create_team.py
+++ b/tests/func/teams/test_create_team.py
@@ -3,7 +3,8 @@ import pytest
 from tests.resources.MutationGenerator import MutationGenerator
 
 
-class TestCreateGroup:
+class TestCreateTeam:
+    # TODO: Break out creating teams as superuser vs regular user after v0.3
 
     @pytest.mark.django_db
     def test_unauthenticated(self, client, team_factory):
@@ -17,11 +18,11 @@ class TestCreateGroup:
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_valid(self, auth_client, team_factory):
+    def test_valid(self, superuser_client, team_factory):
         team = team_factory.build()
 
         mutation = MutationGenerator.create_team(team.name)
-        response = auth_client.post('/graphql', {'query': mutation})
+        response = superuser_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200, response.content
         assert response.json()['data']['createTeam']['team']['name'] == team.name

--- a/tests/func/teams/test_query_teams.py
+++ b/tests/func/teams/test_query_teams.py
@@ -3,25 +3,34 @@ import pytest
 from tests.resources.QueryGenerator import QueryGenerator
 
 
-class TestQueryGroups:
-
+class TestQueryTeams:
     @pytest.mark.django_db
-    def test_get_group(self, team_factory, client):
+    def test_unauthenticated(self, client, team_factory):
         team = team_factory()
 
         query = QueryGenerator.get_team(team.name)
         response = client.post('/graphql', {'query': query})
 
         assert response.status_code == 200, response.content
+        assert not response.json()['data']['team']
+
+    @pytest.mark.django_db
+    def test_get_team(self, user_client, team_factory):
+        team = team_factory(members=[user_client.user])
+
+        query = QueryGenerator.get_team(team.name)
+        response = user_client.post('/graphql', {'query': query})
+
+        assert response.status_code == 200, response.content
         assert response.json()['data']['team']['id'] == str(team.id)
 
     @pytest.mark.django_db
-    def test_get_groups(self, team_factory, client):
-        team_factory()
+    def test_get_teams(self, user_client, team_factory):
+        team_factory(members=[user_client.user])
         team_factory()
 
         query = QueryGenerator.get_teams()
-        response = client.post('/graphql', {'query': query})
+        response = user_client.post('/graphql', {'query': query})
 
         assert response.status_code == 200, response.content
-        assert len(response.json()['data']['teams']) == 2
+        assert len([team for team in response.json()['data']['teams'] if team]) == 1

--- a/tests/func/users/test_create_user.py
+++ b/tests/func/users/test_create_user.py
@@ -4,6 +4,7 @@ from tests.resources.MutationGenerator import MutationGenerator
 
 
 class TestCreateUser:
+    # TODO: Break out creating users as superuser vs anonymous user after v0.3
 
     @pytest.mark.django_db
     def test_unauthenticated(self, client, user_factory):
@@ -17,11 +18,11 @@ class TestCreateUser:
         assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_valid(self, auth_client, user_factory):
+    def test_valid(self, superuser_client, user_factory):
         user = user_factory.build()
 
         mutation = MutationGenerator.create_user(email=user.email, username=user.username)
-        response = auth_client.post('/graphql', {'query': mutation})
+        response = superuser_client.post('/graphql', {'query': mutation})
 
         assert response.status_code == 200, response.content
         assert response.json()['data']['createUser']['user']['id']

--- a/tests/func/users/test_query_users.py
+++ b/tests/func/users/test_query_users.py
@@ -6,7 +6,7 @@ from tests.resources.QueryGenerator import QueryGenerator
 class TestQueryUsers:
 
     @pytest.mark.django_db
-    def test_get_user_unauthorized_fields(self, client, user_factory):
+    def test_get_user_unauthenticated(self, client, user_factory):
         user = user_factory()
 
         query = QueryGenerator.get_user_authorized(user.id)
@@ -14,25 +14,26 @@ class TestQueryUsers:
 
         assert response.status_code == 200, response.content
         assert not response.json()['data']['user']
-        assert response.json()['errors'][0]['message'] == 'Unauthorized'
 
     @pytest.mark.django_db
-    def test_get_user_public_fields(self, client, user_factory):
-        user = user_factory()
+    def test_get_user(self, user_client):
+        jimmy = user_client.user
 
-        query = QueryGenerator.get_user(user.id)
-        response = client.post('/graphql', {'query': query})
+        query = QueryGenerator.get_user(jimmy.id)
+        response = user_client.post('/graphql', {'query': query})
 
         assert response.status_code == 200, response.content
-        assert response.json()['data']['user']['id'] == str(user.id)
+        assert response.json()['data']['user']['id'] == str(jimmy.id)
 
     @pytest.mark.django_db
-    def test_get_users_authorized_fields(self, auth_client, user_factory):
-        user_factory()
-        user_factory()
+    def test_get_users_authorized_fields(self, user_client, user_factory, team_factory):
+        jimmy = user_client.user
+        bobby = user_factory()  # User in team
+        user_factory()  # User not in team
+        team_factory(members=[jimmy, bobby])
 
         query = QueryGenerator.get_users_authorized()
-        response = auth_client.post('/graphql', {'query': query})
+        response = user_client.post('/graphql', {'query': query})
 
         assert response.status_code == 200, response.content
-        assert len(response.json()['data']['users']) == 3
+        assert len([user for user in response.json()['data']['users'] if user]) == 2


### PR DESCRIPTION
- Created authorization decorator that supports authentication and object-level permission checks. When using with mutations, we check authentication and raise an error. When using with queries, we check object-level permissions and return `None`.
- Updated client fixtures. We have a `user_client` that represents a standard user who's logged in. We use this to check queries, etc. We have a `superuser_client` that represents the user coming from SLA. We use this to check mutations, etc.