### PR TITLE
API-153: Implement permission checks on add/change

### DIFF
--- a/app/api/authorization.py
+++ b/app/api/authorization.py
@@ -1,6 +1,6 @@
+import inspect
+
 from rest_framework.authentication import TokenAuthentication
-from django.db import models
-from guardian.shortcuts import get_perms
 
 
 def get_user(context):
@@ -23,27 +23,40 @@ def authenticate(resolve_function):
     return wrapper
 
 
-def authorize(object_level=False, raise_exception=False):
-    def check_authorization(resolve_function):
+def check_permission(permission_name):
+    def wrap_validator_function(validator_function):
         """
-        Performs authorization checks with django-guardian.
+        Performs authorization checks with django-guardian on validator methods.
 
-        Checks to see if the user is authenticated and has
-        view permissions for the object requested.
+        Checks to see if the user is authenticated and has add/change/delete
+        permissions for the model or object.
+        """
+        def wrapper(self, *args):
+            user = self.context['request'].user
+            param_dict = dict(zip(list(inspect.signature(validator_function).parameters.keys()), args))
+
+            if user and user.is_authenticated and user.has_perm(permission_name, param_dict.get('instance')):
+                return validator_function(self, *args)
+
+            raise Exception('Unauthorized')
+        return wrapper
+    return wrap_validator_function
+
+
+def check_view_permission(permission_name):
+    def wrap_resolve_function(resolve_function):
+        """
+        Performs authorization checks with django-guardian on resolver methods.
+
+        Checks to see if the user is authenticated and has view permissions
+        for the object requested.
         """
         def wrapper(self, info, **kwargs):
             user = get_user(info.context)
 
-            if user and user.is_authenticated:
-                if object_level and issubclass(self.__class__, models.Model):
-                    if any('view_' in perm for perm in get_perms(user, self)):
-                        return resolve_function(self, info, **kwargs)
-                else:
-                    return resolve_function(self, info, **kwargs)
+            if user and user.is_authenticated and user.has_perm(permission_name, self):
+                return resolve_function(self, info, **kwargs)
 
-            if raise_exception:
-                raise Exception('Unauthorized')
-
-            return None
+            raise Exception('Unauthorized')
         return wrapper
-    return check_authorization
+    return wrap_resolve_function

--- a/app/api/authorization.py
+++ b/app/api/authorization.py
@@ -23,7 +23,7 @@ def authenticate(resolve_function):
     return wrapper
 
 
-def check_permission(permission_name):
+def check_permission_for_validator(permission_name):
     def wrap_validator_function(validator_function):
         """
         Performs authorization checks with django-guardian on validator methods.
@@ -43,7 +43,7 @@ def check_permission(permission_name):
     return wrap_validator_function
 
 
-def check_view_permission(permission_name):
+def check_permission_for_resolver(permission_name):
     def wrap_resolve_function(resolve_function):
         """
         Performs authorization checks with django-guardian on resolver methods.

--- a/app/api/authorization.py
+++ b/app/api/authorization.py
@@ -14,6 +14,15 @@ def get_user(context):
     return user
 
 
+def authenticate(resolve_function):
+    def wrapper(self, info, **kwargs):
+        user = get_user(info.context)
+        setattr(info.context, 'user', user)
+
+        return resolve_function(self, info, **kwargs)
+    return wrapper
+
+
 def authorize(object_level=False, raise_exception=False):
     def check_authorization(resolve_function):
         """

--- a/app/strands/mutations.py
+++ b/app/strands/mutations.py
@@ -1,6 +1,6 @@
 import graphene
 
-from app.api.authorization import authorize
+from app.api.authorization import authenticate
 from app.strands.types import (
     StrandType,
     StrandInputType,
@@ -16,10 +16,9 @@ class CreateStrandMutation(graphene.Mutation):
 
     strand = graphene.Field(StrandType)
 
-    # TODO: [API-153] Move to authorization to model
-    @authorize(raise_exception=True)
+    @authenticate
     def mutate(self, info, input):
-        strand_validator = StrandValidator(data=input, context={'context': info.context})
+        strand_validator = StrandValidator(data=input, context={'request': info.context})
         strand_validator.is_valid(raise_exception=True)
         strand = strand_validator.save()
         return CreateStrandMutation(strand=strand)
@@ -31,10 +30,9 @@ class CreateTagMutation(graphene.Mutation):
 
     tag = graphene.Field(TagType)
 
-    # TODO: [API-153] Move to authorization to model
-    @authorize(raise_exception=True)
+    @authenticate
     def mutate(self, info, input):
-        tag_validator = TagValidator(data=input, context={'context': info.context})
+        tag_validator = TagValidator(data=input, context={'request': info.context})
         tag_validator.is_valid(raise_exception=True)
         tag = tag_validator.save()
         return CreateTagMutation(tag=tag)

--- a/app/strands/mutations.py
+++ b/app/strands/mutations.py
@@ -19,7 +19,7 @@ class CreateStrandMutation(graphene.Mutation):
     # TODO: [API-153] Move to authorization to model
     @authorize(raise_exception=True)
     def mutate(self, info, input):
-        strand_validator = StrandValidator(data=input)
+        strand_validator = StrandValidator(data=input, context={'context': info.context})
         strand_validator.is_valid(raise_exception=True)
         strand = strand_validator.save()
         return CreateStrandMutation(strand=strand)
@@ -34,7 +34,7 @@ class CreateTagMutation(graphene.Mutation):
     # TODO: [API-153] Move to authorization to model
     @authorize(raise_exception=True)
     def mutate(self, info, input):
-        tag_validator = TagValidator(data=input)
+        tag_validator = TagValidator(data=input, context={'context': info.context})
         tag_validator.is_valid(raise_exception=True)
         tag = tag_validator.save()
         return CreateTagMutation(tag=tag)

--- a/app/strands/types.py
+++ b/app/strands/types.py
@@ -1,7 +1,7 @@
 import graphene
 from graphene_django.types import DjangoObjectType
 
-from app.api.authorization import authorize
+from app.api.authorization import check_view_permission
 from app.strands.models import Strand, Tag
 
 
@@ -10,15 +10,15 @@ class TagType(DjangoObjectType):
         model = Tag
         only_fields = ('id', 'name', 'strands',)
 
-    @authorize(object_level=True)
+    @check_view_permission('view_tag')
     def resolve_id(self, info):
         return self.id
 
-    @authorize(object_level=True)
+    @check_view_permission('view_tag')
     def resolve_name(self, info):
         return self.name
 
-    @authorize(object_level=True)
+    @check_view_permission('view_tag')
     def resolve_strands(self, info):
         return self.strands
 
@@ -28,31 +28,31 @@ class StrandType(DjangoObjectType):
         model = Strand
         only_fields = ('id', 'title', 'body', 'timestamp', 'saver', 'owner', 'tags', )
 
-    @authorize(object_level=True)
+    @check_view_permission('view_strand')
     def resolve_id(self, info):
         return self.id
 
-    @authorize(object_level=True)
+    @check_view_permission('view_strand')
     def resolve_title(self, info):
         return self.title
 
-    @authorize(object_level=True)
+    @check_view_permission('view_strand')
     def resolve_body(self, info):
         return self.body
 
-    @authorize(object_level=True)
+    @check_view_permission('view_strand')
     def resolve_timestamp(self, info):
         return self.timestamp
 
-    @authorize(object_level=True)
+    @check_view_permission('view_strand')
     def resolve_saver(self, info):
         return self.saver
 
-    @authorize(object_level=True)
+    @check_view_permission('view_strand')
     def resolve_owner(self, info):
         return self.owner
 
-    @authorize(object_level=True)
+    @check_view_permission('view_strand')
     def resolve_tags(self, info):
         return self.tags
 

--- a/app/strands/types.py
+++ b/app/strands/types.py
@@ -1,7 +1,7 @@
 import graphene
 from graphene_django.types import DjangoObjectType
 
-from app.api.authorization import check_view_permission
+from app.api.authorization import check_permission_for_resolver
 from app.strands.models import Strand, Tag
 
 
@@ -10,15 +10,15 @@ class TagType(DjangoObjectType):
         model = Tag
         only_fields = ('id', 'name', 'strands',)
 
-    @check_view_permission('view_tag')
+    @check_permission_for_resolver('view_tag')
     def resolve_id(self, info):
         return self.id
 
-    @check_view_permission('view_tag')
+    @check_permission_for_resolver('view_tag')
     def resolve_name(self, info):
         return self.name
 
-    @check_view_permission('view_tag')
+    @check_permission_for_resolver('view_tag')
     def resolve_strands(self, info):
         return self.strands
 
@@ -28,31 +28,31 @@ class StrandType(DjangoObjectType):
         model = Strand
         only_fields = ('id', 'title', 'body', 'timestamp', 'saver', 'owner', 'tags', )
 
-    @check_view_permission('view_strand')
+    @check_permission_for_resolver('view_strand')
     def resolve_id(self, info):
         return self.id
 
-    @check_view_permission('view_strand')
+    @check_permission_for_resolver('view_strand')
     def resolve_title(self, info):
         return self.title
 
-    @check_view_permission('view_strand')
+    @check_permission_for_resolver('view_strand')
     def resolve_body(self, info):
         return self.body
 
-    @check_view_permission('view_strand')
+    @check_permission_for_resolver('view_strand')
     def resolve_timestamp(self, info):
         return self.timestamp
 
-    @check_view_permission('view_strand')
+    @check_permission_for_resolver('view_strand')
     def resolve_saver(self, info):
         return self.saver
 
-    @check_view_permission('view_strand')
+    @check_permission_for_resolver('view_strand')
     def resolve_owner(self, info):
         return self.owner
 
-    @check_view_permission('view_strand')
+    @check_permission_for_resolver('view_strand')
     def resolve_tags(self, info):
         return self.tags
 

--- a/app/strands/validators.py
+++ b/app/strands/validators.py
@@ -2,8 +2,9 @@
 
 from rest_framework import serializers
 
-from app.teams.models import Team
+from app.api.authorization import check_permission
 from app.strands.models import Strand, Tag
+from app.teams.models import Team
 from app.users.models import User
 
 
@@ -16,15 +17,15 @@ class StrandValidator(serializers.ModelSerializer):
         model = Strand
         fields = ('title', 'body', 'timestamp', 'saver_id', 'owner_id', 'tags')
 
+    @check_permission('add_strand')
     def create(self, validated_data):
-        # TODO: Check add_strand permission
         tags = validated_data.pop('tags', [])
         strand = super().create(validated_data)
         strand.add_tags(tags)
         return strand
 
+    @check_permission('change_strand')
     def update(self, instance, validated_data):
-        # TODO: Check change_strand permission
         tags = validated_data.pop('tags', [])
         strand = super().update(instance, validated_data)
         strand.add_tags(tags)
@@ -36,12 +37,15 @@ class TagValidator(serializers.ModelSerializer):
         model = Tag
         fields = ('name', )
 
+    @check_permission('add_tag')
     def create(self, validated_data):
-        # TODO: Check add_tag permission
         tag = super().create(validated_data)
         return tag
 
+    @check_permission('change_tag')
     def update(self, instance, validated_data):
-        # TODO: Check change_tag permission
         tag = super().update(instance, validated_data)
         return tag
+
+
+# TODO: [API-164] Implement delete

--- a/app/strands/validators.py
+++ b/app/strands/validators.py
@@ -17,8 +17,16 @@ class StrandValidator(serializers.ModelSerializer):
         fields = ('title', 'body', 'timestamp', 'saver_id', 'owner_id', 'tags')
 
     def create(self, validated_data):
+        # TODO: Check add_strand permission
         tags = validated_data.pop('tags', [])
-        strand = Strand.objects.create(**validated_data)
+        strand = super().create(validated_data)
+        strand.add_tags(tags)
+        return strand
+
+    def update(self, instance, validated_data):
+        # TODO: Check change_strand permission
+        tags = validated_data.pop('tags', [])
+        strand = super().update(instance, validated_data)
         strand.add_tags(tags)
         return strand
 
@@ -27,3 +35,13 @@ class TagValidator(serializers.ModelSerializer):
     class Meta:
         model = Tag
         fields = ('name', )
+
+    def create(self, validated_data):
+        # TODO: Check add_tag permission
+        tag = super().create(validated_data)
+        return tag
+
+    def update(self, instance, validated_data):
+        # TODO: Check change_tag permission
+        tag = super().update(instance, validated_data)
+        return tag

--- a/app/strands/validators.py
+++ b/app/strands/validators.py
@@ -2,7 +2,7 @@
 
 from rest_framework import serializers
 
-from app.api.authorization import check_permission
+from app.api.authorization import check_permission_for_validator
 from app.strands.models import Strand, Tag
 from app.teams.models import Team
 from app.users.models import User
@@ -17,14 +17,14 @@ class StrandValidator(serializers.ModelSerializer):
         model = Strand
         fields = ('title', 'body', 'timestamp', 'saver_id', 'owner_id', 'tags')
 
-    @check_permission('add_strand')
+    @check_permission_for_validator('add_strand')
     def create(self, validated_data):
         tags = validated_data.pop('tags', [])
         strand = super().create(validated_data)
         strand.add_tags(tags)
         return strand
 
-    @check_permission('change_strand')
+    @check_permission_for_validator('change_strand')
     def update(self, instance, validated_data):
         tags = validated_data.pop('tags', [])
         strand = super().update(instance, validated_data)
@@ -37,12 +37,12 @@ class TagValidator(serializers.ModelSerializer):
         model = Tag
         fields = ('name', )
 
-    @check_permission('add_tag')
+    @check_permission_for_validator('add_tag')
     def create(self, validated_data):
         tag = super().create(validated_data)
         return tag
 
-    @check_permission('change_tag')
+    @check_permission_for_validator('change_tag')
     def update(self, instance, validated_data):
         tag = super().update(instance, validated_data)
         return tag

--- a/app/teams/mutations.py
+++ b/app/teams/mutations.py
@@ -14,7 +14,7 @@ class CreateTeamMutation(graphene.Mutation):
     # TODO: [API-153] Move to authorization to model
     @authorize(raise_exception=True)
     def mutate(self, info, input):
-        team_validator = TeamValidator(data=input)
+        team_validator = TeamValidator(data=input, context={'context': info.context})
         team_validator.is_valid(raise_exception=True)
         team = team_validator.save()
 

--- a/app/teams/mutations.py
+++ b/app/teams/mutations.py
@@ -1,6 +1,6 @@
 import graphene
 
-from app.api.authorization import authorize
+from app.api.authorization import authenticate
 from app.teams.validators import TeamValidator
 from app.teams.types import TeamType, TeamInputType
 
@@ -11,10 +11,9 @@ class CreateTeamMutation(graphene.Mutation):
 
     team = graphene.Field(TeamType)
 
-    # TODO: [API-153] Move to authorization to model
-    @authorize(raise_exception=True)
+    @authenticate
     def mutate(self, info, input):
-        team_validator = TeamValidator(data=input, context={'context': info.context})
+        team_validator = TeamValidator(data=input, context={'request': info.context})
         team_validator.is_valid(raise_exception=True)
         team = team_validator.save()
 

--- a/app/teams/types.py
+++ b/app/teams/types.py
@@ -1,7 +1,7 @@
 import graphene
 from graphene_django.types import DjangoObjectType
 
-from app.api.authorization import authorize
+from app.api.authorization import check_view_permission
 from app.teams.models import Team
 
 
@@ -10,19 +10,19 @@ class TeamType(DjangoObjectType):
         model = Team
         only_fields = ('id', 'name', 'members', 'strands',)
 
-    @authorize(object_level=True)
+    @check_view_permission('view_team')
     def resolve_id(self, info):
         return self.id
 
-    @authorize(object_level=True)
+    @check_view_permission('view_team')
     def resolve_name(self, info):
         return self.name
 
-    @authorize(object_level=True)
+    @check_view_permission('view_team')
     def resolve_members(self, info):
         return self.members
 
-    @authorize(object_level=True)
+    @check_view_permission('view_team')
     def resolve_strands(self, info):
         return self.strands
 

--- a/app/teams/types.py
+++ b/app/teams/types.py
@@ -1,7 +1,7 @@
 import graphene
 from graphene_django.types import DjangoObjectType
 
-from app.api.authorization import check_view_permission
+from app.api.authorization import check_permission_for_resolver
 from app.teams.models import Team
 
 
@@ -10,19 +10,19 @@ class TeamType(DjangoObjectType):
         model = Team
         only_fields = ('id', 'name', 'members', 'strands',)
 
-    @check_view_permission('view_team')
+    @check_permission_for_resolver('view_team')
     def resolve_id(self, info):
         return self.id
 
-    @check_view_permission('view_team')
+    @check_permission_for_resolver('view_team')
     def resolve_name(self, info):
         return self.name
 
-    @check_view_permission('view_team')
+    @check_permission_for_resolver('view_team')
     def resolve_members(self, info):
         return self.members
 
-    @check_view_permission('view_team')
+    @check_permission_for_resolver('view_team')
     def resolve_strands(self, info):
         return self.strands
 

--- a/app/teams/validators.py
+++ b/app/teams/validators.py
@@ -2,6 +2,7 @@
 
 from rest_framework import serializers
 
+from app.api.authorization import check_permission
 from app.teams.models import Team
 
 
@@ -12,12 +13,15 @@ class TeamValidator(serializers.ModelSerializer):
         model = Team
         fields = ('id', 'name')
 
+    @check_permission('add_team')
     def create(self, validated_data):
-        # TODO: Check add_team permission
-        team = super().create(**validated_data)
+        team = super().create(validated_data)
         return team
 
+    @check_permission('change_team')
     def update(self, instance, validated_data):
-        # TODO: Check change_team permission
         team = super().update(instance, validated_data)
         return team
+
+
+# TODO: [API-164] Implement delete

--- a/app/teams/validators.py
+++ b/app/teams/validators.py
@@ -11,3 +11,13 @@ class TeamValidator(serializers.ModelSerializer):
     class Meta:
         model = Team
         fields = ('id', 'name')
+
+    def create(self, validated_data):
+        # TODO: Check add_team permission
+        team = super().create(**validated_data)
+        return team
+
+    def update(self, instance, validated_data):
+        # TODO: Check change_team permission
+        team = super().update(instance, validated_data)
+        return team

--- a/app/teams/validators.py
+++ b/app/teams/validators.py
@@ -2,7 +2,7 @@
 
 from rest_framework import serializers
 
-from app.api.authorization import check_permission
+from app.api.authorization import check_permission_for_validator
 from app.teams.models import Team
 
 
@@ -13,12 +13,12 @@ class TeamValidator(serializers.ModelSerializer):
         model = Team
         fields = ('id', 'name')
 
-    @check_permission('add_team')
+    @check_permission_for_validator('add_team')
     def create(self, validated_data):
         team = super().create(validated_data)
         return team
 
-    @check_permission('change_team')
+    @check_permission_for_validator('change_team')
     def update(self, instance, validated_data):
         team = super().update(instance, validated_data)
         return team

--- a/app/users/mutations.py
+++ b/app/users/mutations.py
@@ -1,6 +1,6 @@
 import graphene
 
-from app.api.authorization import authorize
+from app.api.authorization import authenticate
 from app.users.types import UserInputType, UserType
 from app.users.validators import UserValidator
 
@@ -11,10 +11,9 @@ class CreateUserMutation(graphene.Mutation):
 
     user = graphene.Field(UserType)
 
-    # TODO: [API-153] Move to authorization to model
-    @authorize(raise_exception=True)
+    @authenticate
     def mutate(self, info, input):
-        user_validator = UserValidator(data=input, context={'context': info.context})
+        user_validator = UserValidator(data=input, context={'request': info.context})
         user_validator.is_valid(raise_exception=True)
         user = user_validator.save()
 

--- a/app/users/mutations.py
+++ b/app/users/mutations.py
@@ -14,7 +14,7 @@ class CreateUserMutation(graphene.Mutation):
     # TODO: [API-153] Move to authorization to model
     @authorize(raise_exception=True)
     def mutate(self, info, input):
-        user_validator = UserValidator(data=input)
+        user_validator = UserValidator(data=input, context={'context': info.context})
         user_validator.is_valid(raise_exception=True)
         user = user_validator.save()
 

--- a/app/users/types.py
+++ b/app/users/types.py
@@ -1,7 +1,7 @@
 import graphene
 from graphene_django.types import DjangoObjectType
 
-from app.api.authorization import authorize
+from app.api.authorization import check_view_permission
 from app.users.models import User
 
 
@@ -10,23 +10,23 @@ class UserType(DjangoObjectType):
         model = User
         only_fields = ('id', 'email', 'first_name', 'last_name', 'teams', 'strands',)
 
-    @authorize(object_level=True)
+    @check_view_permission('view_user')
     def resolve_email(self, info):
         return self.email
 
-    @authorize(object_level=True)
+    @check_view_permission('view_user')
     def resolve_first_name(self, info):
         return self.first_name
 
-    @authorize(object_level=True)
+    @check_view_permission('view_user')
     def resolve_last_name(self, info):
         return self.last_name
 
-    @authorize(object_level=True)
+    @check_view_permission('view_user')
     def resolve_teams(self, info):
         return self.teams.all()
 
-    @authorize(object_level=True)
+    @check_view_permission('view_user')
     def resolve_strands(self, info):
         return self.strands.all()
 

--- a/app/users/types.py
+++ b/app/users/types.py
@@ -1,7 +1,7 @@
 import graphene
 from graphene_django.types import DjangoObjectType
 
-from app.api.authorization import check_view_permission
+from app.api.authorization import check_permission_for_resolver
 from app.users.models import User
 
 
@@ -10,23 +10,23 @@ class UserType(DjangoObjectType):
         model = User
         only_fields = ('id', 'email', 'first_name', 'last_name', 'teams', 'strands',)
 
-    @check_view_permission('view_user')
+    @check_permission_for_resolver('view_user')
     def resolve_email(self, info):
         return self.email
 
-    @check_view_permission('view_user')
+    @check_permission_for_resolver('view_user')
     def resolve_first_name(self, info):
         return self.first_name
 
-    @check_view_permission('view_user')
+    @check_permission_for_resolver('view_user')
     def resolve_last_name(self, info):
         return self.last_name
 
-    @check_view_permission('view_user')
+    @check_permission_for_resolver('view_user')
     def resolve_teams(self, info):
         return self.teams.all()
 
-    @check_view_permission('view_user')
+    @check_permission_for_resolver('view_user')
     def resolve_strands(self, info):
         return self.strands.all()
 

--- a/app/users/validators.py
+++ b/app/users/validators.py
@@ -2,7 +2,7 @@
 
 from rest_framework import serializers
 
-from app.api.authorization import check_permission
+from app.api.authorization import check_permission_for_validator
 from app.users.models import User
 
 
@@ -11,12 +11,12 @@ class UserValidator(serializers.ModelSerializer):
         model = User
         fields = ('email', 'username', 'first_name', 'last_name',)
 
-    @check_permission('add_user')
+    @check_permission_for_validator('add_user')
     def create(self, validated_data):
         user = super().create(validated_data)
         return user
 
-    @check_permission('change_user')
+    @check_permission_for_validator('change_user')
     def update(self, instance, validated_data):
         user = super().update(instance, validated_data)
         return user

--- a/app/users/validators.py
+++ b/app/users/validators.py
@@ -12,10 +12,12 @@ class UserValidator(serializers.ModelSerializer):
 
     def create(self, validated_data):
         # TODO: check add_user permissions
+        print(self.context['request'].user)
         user = super().create(validated_data)
         return user
 
     def update(self, instance, validated_data):
         # TODO: check change_user permission
+        print(self.context['request'].user)
         user = super().update(instance, validated_data)
         return user

--- a/app/users/validators.py
+++ b/app/users/validators.py
@@ -11,5 +11,11 @@ class UserValidator(serializers.ModelSerializer):
         fields = ('email', 'username', 'first_name', 'last_name',)
 
     def create(self, validated_data):
-        user = User.objects.create(**validated_data)
+        # TODO: check add_user permissions
+        user = super().create(validated_data)
+        return user
+
+    def update(self, instance, validated_data):
+        # TODO: check change_user permission
+        user = super().update(instance, validated_data)
         return user

--- a/app/users/validators.py
+++ b/app/users/validators.py
@@ -2,6 +2,7 @@
 
 from rest_framework import serializers
 
+from app.api.authorization import check_permission
 from app.users.models import User
 
 
@@ -10,14 +11,15 @@ class UserValidator(serializers.ModelSerializer):
         model = User
         fields = ('email', 'username', 'first_name', 'last_name',)
 
+    @check_permission('add_user')
     def create(self, validated_data):
-        # TODO: check add_user permissions
-        print(self.context['request'].user)
         user = super().create(validated_data)
         return user
 
+    @check_permission('change_user')
     def update(self, instance, validated_data):
-        # TODO: check change_user permission
-        print(self.context['request'].user)
         user = super().update(instance, validated_data)
         return user
+
+
+# TODO: [API-164] Implement delete


### PR DESCRIPTION
- Refactored authorization to use object-level permissions.
- We use the `@authenticate` decorator on mutations to extract the user from the request metadata (e.g. grab token from authorization header) and pass the user to the validator as the request context
- Within the request context we see if this user has the permission to add/change the model/instance.
- On queries we check view permissions in a less jank way by passing the permission name.
- Future todos include API-164 that covers the delete validator methods (not necessary for 0.3) and API-160 that covers the add permissions (not necessary for 0.3).