### PR TITLE
API-156: Add members to team

### DIFF
--- a/app/teams/mutations.py
+++ b/app/teams/mutations.py
@@ -1,8 +1,13 @@
 import graphene
 
 from app.api.authorization import authenticate
+from app.teams.models import Team
 from app.teams.validators import TeamValidator
-from app.teams.types import TeamType, TeamInputType
+from app.teams.types import (
+    TeamType,
+    TeamInputType,
+    AddMembersToTeamInputType
+)
 
 
 class CreateTeamMutation(graphene.Mutation):
@@ -20,5 +25,23 @@ class CreateTeamMutation(graphene.Mutation):
         return CreateTeamMutation(team=team)
 
 
+class AddMembersToTeamMutation(graphene.Mutation):
+    class Arguments:
+        input = AddMembersToTeamInputType(required=True)
+
+    team = graphene.Field(TeamType)
+
+    @authenticate
+    def mutate(self, info, input):
+        team = Team.objects.get(id=input.pop('id'))
+        team_validator = TeamValidator(instance=team, data=input, context={'request': info.context,
+                                                                           'member_operation': 'add'}, partial=True)
+        team_validator.is_valid(raise_exception=True)
+        team = team_validator.save()
+
+        return AddMembersToTeamMutation(team=team)
+
+
 class Mutation(graphene.ObjectType):
     create_team = CreateTeamMutation.Field()
+    add_members_to_team = AddMembersToTeamMutation.Field()

--- a/app/teams/types.py
+++ b/app/teams/types.py
@@ -30,3 +30,8 @@ class TeamType(DjangoObjectType):
 class TeamInputType(graphene.InputObjectType):
     # TODO: [API-157] FKs of users to include on creation
     name = graphene.String(required=True)
+
+
+class AddMembersToTeamInputType(graphene.InputObjectType):
+    id = graphene.Int(required=True)
+    member_ids = graphene.List(graphene.Int, required=True)

--- a/app/teams/validators.py
+++ b/app/teams/validators.py
@@ -4,14 +4,16 @@ from rest_framework import serializers
 
 from app.api.authorization import check_permission_for_validator
 from app.teams.models import Team
+from app.users.models import User
 
 
 class TeamValidator(serializers.ModelSerializer):
     # TODO: [API-157] FKs of users to include on creation
+    member_ids = serializers.PrimaryKeyRelatedField(queryset=User.objects.all(), many=True, required=False)
 
     class Meta:
         model = Team
-        fields = ('id', 'name')
+        fields = ('id', 'name', 'member_ids')
 
     @check_permission_for_validator('add_team')
     def create(self, validated_data):
@@ -20,7 +22,16 @@ class TeamValidator(serializers.ModelSerializer):
 
     @check_permission_for_validator('change_team')
     def update(self, instance, validated_data):
+        members = validated_data.pop('member_ids', [])
         team = super().update(instance, validated_data)
+
+        # For the addMembersToTeam mutation, we just want to "add" members.
+        if self.context['member_operation'] == 'add':
+            team.members.add(*members)
+        # If we add an update team mutation, we'll want to "set" the members.
+        elif self.context['member_operation'] == 'set':
+            team.members.set(*members)
+
         return team
 
 

--- a/tests/func/teams/test_add_members_to_team.py
+++ b/tests/func/teams/test_add_members_to_team.py
@@ -1,0 +1,43 @@
+import pytest
+
+from tests.resources.MutationGenerator import MutationGenerator
+
+
+class TestAddMembersToTeam:
+    # TODO: Break out creating teams as superuser vs regular user after v0.3
+
+    @pytest.mark.django_db
+    def test_unauthenticated(self, client, team_factory, user_factory):
+        team = team_factory()
+        jimmy = user_factory()
+
+        mutation = MutationGenerator.add_members_to_team(id=team.id, member_ids=[jimmy.id])
+        response = client.post('/graphql', {'query': mutation})
+
+        assert response.status_code == 200, response.content
+        assert not response.json()['data']['addMembersToTeam']
+        assert response.json()['errors'][0]['message'] == 'Unauthorized'
+
+    @pytest.mark.django_db
+    def test_invalid_user(self, superuser_client, team_factory, user_factory):
+        team = team_factory()
+        jimmy = user_factory()
+
+        mutation = MutationGenerator.add_members_to_team(id=team.id, member_ids=[jimmy.id + 1])
+        response = superuser_client.post('/graphql', {'query': mutation})
+
+        assert response.status_code == 200, response.content
+        assert not response.json()['data']['addMembersToTeam']
+        assert response.json()['errors'][0]['message'] == str({'member_ids': [f'Invalid pk "{jimmy.id + 1}" '
+                                                                              f'- object does not exist.']})
+
+    @pytest.mark.django_db
+    def test_valid(self, superuser_client, team_factory, user_factory):
+        team = team_factory(members=[user_factory()])
+        jimmy = user_factory()
+
+        mutation = MutationGenerator.add_members_to_team(id=team.id, member_ids=[jimmy.id])
+        response = superuser_client.post('/graphql', {'query': mutation})
+
+        assert response.status_code == 200, response.content
+        assert response.json()['data']['addMembersToTeam']['team']['members'][1]['email'] == jimmy.email

--- a/tests/resources/MutationGenerator.py
+++ b/tests/resources/MutationGenerator.py
@@ -5,14 +5,30 @@ class TeamsMutationGenerator:
     @staticmethod
     def create_team(team_name):
         mutation = f'''
-              mutation {{
-                createTeam(input: {{name: "{team_name}"}}) {{
-                  team {{
-                    name
-                  }}
+          mutation {{
+            createTeam(input: {{name: "{team_name}"}}) {{
+              team {{
+                name
+              }}
+            }}
+          }}
+        '''
+        return mutation
+
+    @staticmethod
+    def add_members_to_team(id, member_ids):
+        mutation = f'''
+          mutation {{
+            addMembersToTeam(input: {{id: {id}, memberIds: {[member_id for member_id in member_ids]}}}) {{
+              team {{
+                name
+                members {{
+                  email
                 }}
               }}
-            '''
+            }} 
+          }}
+        '''
         return mutation
 
 

--- a/tests/resources/MutationGenerator.py
+++ b/tests/resources/MutationGenerator.py
@@ -26,7 +26,7 @@ class TeamsMutationGenerator:
                   email
                 }}
               }}
-            }} 
+            }}
           }}
         '''
         return mutation


### PR DESCRIPTION
- Update TeamValidator to accept a `member_ids` field which is a list of User PKs
- Update TeamValidator `update` method to add or set members based upon "member_operation". This is a context value passed in from the mutation. This allows us to either add or set members.